### PR TITLE
Open up the support for Python>=3.9 to align with Kedro 0.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.9", "3.10","3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       # Download the Databricks CLI.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/JenspederM/kedro-databricks/graph/badge.svg?token=0MUFV8BNRH)](https://codecov.io/gh/JenspederM/kedro-databricks)
 <a href="https://codeclimate.com/github/JenspederM/kedro-databricks/maintainability"><img src="https://api.codeclimate.com/v1/badges/d5ef60eb0f20cb369b18/maintainability" /></a>
-[![Python Version](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)](https://pypi.org/project/kedro-databricks/)
+[![Python Version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/kedro-databricks/)
 [![PyPI Version](https://badge.fury.io/py/kedro-databricks.svg)](https://pypi.org/project/kedro-databricks/)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dev-dependencies = [
     "pytest>=8.2.2",
     "pytest-cov>=5.0.0",
     "isort>=5.13.2",
-    "ipython>=8.26.0",
-    "notebook>=7.2.1",
+    "ipython",
+    "notebook",
     "pre-commit>=3.7.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A plugin to run Kedro pipelines on Databricks."
 authors = [{ name = "Jens Peder Meldgaard", email = "jenspederm@gmail.com" }]
 dependencies = ["kedro>=0.19.0", "mergedeep>=1.3.4", "tomlkit>=0.13.0"]
 readme = "README.md"
-requires-python = ">= 3.11"
+requires-python = ">= 3.9"
 
 [project.urls]
 Homepage = "https://github.com/jenspederm/kedro-databricks"


### PR DESCRIPTION
Is there a specific reason why this only support Python 3.11+? It looks like it can support 3.9+ that aligns with Kedro 0.19+