### PR TITLE
Feat/add multi cloud support

### DIFF
--- a/scripts/mkdev.sh
+++ b/scripts/mkdev.sh
@@ -24,7 +24,7 @@ fi
 rye build
 
 # Create a new project
-kedro new --starter="https://github.com/JenspederM/kedro-starters" --directory="databricks-iris" --checkout="feat/align-databricks-iris-with-kedro-databricks" --name="$1"
+kedro new --starter="databricks-iris" --name="$1"
 # kedro new --starter=databricks-iris --name="$1"
 
 # Databricks needs Java

--- a/src/kedro_databricks/plugin.py
+++ b/src/kedro_databricks/plugin.py
@@ -33,6 +33,17 @@ from kedro_databricks.init import (
 DEFAULT_RUN_ENV = "local"
 DEFAULT_CONFIG_KEY = "default"
 DEFAULT_CONFIG_HELP = "Set the key for the default configuration"
+_PROVIDER_PROMPT = """
+Please select your cloud provider:
+1. Azure
+2. AWS
+3. GCP
+"""
+_PROVIDER_MAP = {
+    "1": "azure",
+    "2": "aws",
+    "3": "gcp",
+}
 
 
 @click.group(name="Kedro-Databricks")
@@ -87,14 +98,16 @@ def _load_env_config(metadata: ProjectMetadata, env: str, MSG: str):
 
 @databricks_commands.command()
 @click.option("-d", "--default", default=DEFAULT_CONFIG_KEY, help=DEFAULT_CONFIG_HELP)
+@click.option("--provider", prompt=_PROVIDER_PROMPT, default="1")
 @click.pass_obj
 def init(
     metadata: ProjectMetadata,
     default: str,
+    provider: str,
 ):
     """Initialize Databricks Asset Bundle configuration"""
     write_bundle_template(metadata)
-    write_override_template(metadata, default)
+    write_override_template(metadata, default, _PROVIDER_MAP.get(provider))
     write_databricks_run_script(metadata)
     substitute_catalog_paths(metadata)
 

--- a/src/kedro_databricks/utils.py
+++ b/src/kedro_databricks/utils.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import copy
 import logging
 import subprocess
-from typing import Any, Union
+from typing import Any
 
 TASK_KEY_ORDER = [
     "task_key",
@@ -26,7 +28,7 @@ WORKFLOW_KEY_ORDER = [
 
 def run_cmd(
     cmd: list[str], msg: str = "Failed to run command", warn: bool = False
-) -> Union[subprocess.CompletedProcess, None]:
+) -> subprocess.CompletedProcess | None:
     """Run a shell command.
 
     Args:
@@ -77,8 +79,8 @@ def _is_null_or_empty(x: Any) -> bool:
 
 
 def _remove_nulls_from_list(
-    lst: list[Union[dict, float, int, str, bool]],
-) -> list[Union[dict, list]]:
+    lst: list[dict | float | int | str | bool],
+) -> list[dict | list]:
     """Remove None values from a list.
 
     Args:
@@ -97,7 +99,7 @@ def _remove_nulls_from_list(
 
 def _remove_nulls_from_dict(
     d: dict[str, Any],
-) -> dict[str, Union[float, int, str, bool]]:
+) -> dict[str, float | int | str | bool]:
     """Remove None values from a dictionary.
 
     Args:
@@ -115,7 +117,7 @@ def _remove_nulls_from_dict(
     return d
 
 
-def remove_nulls(value: Union[dict, list]) -> Union[dict, list]:
+def remove_nulls(value: dict | list) -> dict | list:
     """Remove None values from a dictionary or list.
 
     Args:


### PR DESCRIPTION
Adds "multi-cloud support" by providing an option to select cloud provider in the init command. 

Switching provider will change the node_type_id in the configuration example, thereby ensuring that users are able to deploy and run without having to make alterations. 