### PR TITLE
fix(deploy): fix typo for debug short cli name

### DIFF
--- a/src/kedro_databricks/plugin.py
+++ b/src/kedro_databricks/plugin.py
@@ -131,7 +131,7 @@ def bundle(
     default=False,
     help="Bundle the project before deploying",
 )
-@click.option("-b", "--debug/--no-debug", default=False, help="Enable debug mode")
+@click.option("-d", "--debug/--no-debug", default=False, help="Enable debug mode")
 @click.pass_obj
 def deploy(
     metadata: ProjectMetadata,


### PR DESCRIPTION
Short cli parameter name for debug was incorrectly set to b, collisionning with bundle one.