### PR TITLE
feat(deploy): add a target cli option to deploy

### DIFF
--- a/src/kedro_databricks/deploy.py
+++ b/src/kedro_databricks/deploy.py
@@ -166,17 +166,17 @@ def build_project(metadata: ProjectMetadata, MSG: str):  # pragma: no cover
     return result
 
 
-def deploy_project(metadata: ProjectMetadata, MSG: str, env: str, debug: bool = False):
+def deploy_project(metadata: ProjectMetadata, MSG: str, target: str, debug: bool = False):
     """Deploy the project to Databricks.
 
     Args:
         metadata (ProjectMetadata): Project metadata.
         MSG (str): Message to display.
-        env (str): Environment to deploy to.
+        target (str): Databricks target environment to deploy to.
     """
     log = logging.getLogger(metadata.package_name)
-    log.info(f"{MSG}: Running `databricks bundle deploy --target {env}`")
-    deploy_cmd = ["databricks", "bundle", "deploy", "--target", env]
+    log.info(f"{MSG}: Running `databricks bundle deploy --target {target}`")
+    deploy_cmd = ["databricks", "bundle", "deploy", "--target", target]
     if debug:
         deploy_cmd.append("--debug")
     run_cmd(deploy_cmd, msg=MSG)

--- a/src/kedro_databricks/plugin.py
+++ b/src/kedro_databricks/plugin.py
@@ -167,4 +167,4 @@ def deploy(
     create_dbfs_dir(metadata, MSG=MSG)
     upload_project_config(metadata, MSG=MSG)
     upload_project_data(metadata, MSG=MSG)
-    deploy_project(metadata, MSG=MSG, env=env, debug=debug)
+    deploy_project(metadata, MSG=MSG, target=env, debug=debug)

--- a/src/kedro_databricks/plugin.py
+++ b/src/kedro_databricks/plugin.py
@@ -138,6 +138,7 @@ def bundle(
 
 @databricks_commands.command()
 @click.option("-e", "--env", default=DEFAULT_RUN_ENV, help=ENV_HELP)
+@click.option("-t", "--target", default=None, help="Databricks target environment. Defaults to the `env` value.")
 @click.option(
     "-b",
     "--bundle/--no-bundle",
@@ -149,6 +150,7 @@ def bundle(
 def deploy(
     metadata: ProjectMetadata,
     env: str,
+    target: str | None,
     bundle: bool,
     debug: bool,
 ):
@@ -167,4 +169,6 @@ def deploy(
     create_dbfs_dir(metadata, MSG=MSG)
     upload_project_config(metadata, MSG=MSG)
     upload_project_data(metadata, MSG=MSG)
-    deploy_project(metadata, MSG=MSG, target=env, debug=debug)
+    if target is None:
+        target = env
+    deploy_project(metadata, MSG=MSG, target=target, debug=debug)


### PR DESCRIPTION
Add target cli option to give the user the ability to choose the databricks target environment independently from the kedro environment.

If not set, defaults to the previous behaviour by using the `env` value.