### PR TITLE
feat(deploy): add conf option to the bundle and the deploy commands

### DIFF
--- a/src/kedro_databricks/deploy.py
+++ b/src/kedro_databricks/deploy.py
@@ -104,11 +104,12 @@ def upload_project_data(metadata: ProjectMetadata, MSG: str):  # pragma: no cove
     log.info(f"{MSG}: Data uploaded to {target_path}")
 
 
-def upload_project_config(metadata: ProjectMetadata, MSG: str):  # pragma: no cover
+def upload_project_config(metadata: ProjectMetadata, conf: str, MSG: str):  # pragma: no cover
     """Upload the project configuration to DBFS.
 
     Args:
         metadata (ProjectMetadata): Project metadata.
+        conf (str): The conf folder.
         MSG (str): Message to display.
     """
     package_name = metadata.package_name
@@ -118,8 +119,8 @@ def upload_project_config(metadata: ProjectMetadata, MSG: str):  # pragma: no co
     with tarfile.open(project_path / f"dist/conf-{package_name}.tar.gz") as f:
         f.extractall("dist/", filter="tar")
 
-    target_path = f"dbfs:/FileStore/{package_name}/conf"
-    source_path = project_path / "dist" / "conf"
+    target_path = f"dbfs:/FileStore/{package_name}/{conf}"
+    source_path = project_path / "dist" / conf
     if not source_path.exists():
         raise FileNotFoundError(f"Configuration path {source_path} does not exist")
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -84,6 +84,58 @@ def test_databricks_bundle_with_overrides(kedro_project, cli_runner, metadata):
                     assert params[j + 1] == "dev"
 
 
+def test_databricks_bundle_with_conf(kedro_project, cli_runner, metadata):
+    """Test the `bundle` command"""
+
+    init_cmd = ["databricks", "init"]
+    result = cli_runner.invoke(commands, init_cmd, obj=metadata)
+    override_path = metadata.project_path / "conf" / "sub_pipeline" / "base" / "databricks.yml"
+    assert result.exit_code == 0, (result.exit_code, result.stdout)
+    override_path.unlink(missing_ok=True)
+    assert not override_path.exists(), "Override file not created"
+
+    command = ["databricks", "bundle", "--env", "dev", "--conf", "conf/sub_pipeline"]
+    result = cli_runner.invoke(commands, command, obj=metadata)
+    resource_dir = kedro_project / "resources"
+    conf_dir = kedro_project / "conf" / "sub_pipeline" / "dev"
+    assert result.exit_code == 0, (result.exit_code, result.stdout)
+    assert resource_dir.exists(), "Resource directory not created"
+    assert resource_dir.is_dir(), "Resource directory is not a directory"
+    assert conf_dir.exists(), "Configuration directory not created"
+
+    files = [p.name for p in resource_dir.rglob("*")]
+    files.sort()
+    assert files == [
+        f"{metadata.package_name}.yml",
+        f"{metadata.package_name}_ds.yml",
+    ], f"Resource files not created: {', '.join(files)}"
+
+    resources_without_overrides = []
+    for p in files:
+        with open(resource_dir / p) as f:
+            resource = yaml.safe_load(f)
+            resources_without_overrides.append(resource)
+
+    for resource, file_name in zip(resources_without_overrides, files):
+        assert resource.get("resources") is not None
+
+        jobs = resource["resources"]["jobs"]
+        assert len(jobs) == 1
+
+        job = jobs.get(file_name.split(".")[0])
+        assert job is not None
+
+        tasks = job.get("tasks")
+        assert tasks is not None
+        assert len(tasks) == 5
+
+        for i, task in enumerate(tasks):
+            assert task.get("task_key") == f"node{i}"
+            params = task.get("python_wheel_task").get("parameters")
+            for j, param in enumerate(params):
+                if param == "--env":
+                    assert params[j + 1] == "dev"
+
 def test_databricks_bundle_without_overrides(kedro_project, cli_runner, metadata):
     """Test the `bundle` command"""
 
@@ -152,5 +204,24 @@ def test_deploy(kedro_project, cli_runner, metadata):
     assert override_path.exists(), "Override file not created"
 
     deploy_cmd = ["databricks", "deploy", "--bundle", "--debug"]
+    result = cli_runner.invoke(commands, deploy_cmd, obj=metadata)
+    assert result.exit_code == 0, (result.exit_code, result.stdout)
+
+
+def test_deploy_with_conf(kedro_project, cli_runner, metadata):
+    """Test the `deploy` command"""
+    deploy_fail = ["databricks", "deploy"]
+    result = cli_runner.invoke(commands, deploy_fail, obj=metadata)
+    assert result.exit_code == 1, (result.exit_code, result.stdout)
+
+    init_cmd = ["databricks", "init"]
+    result = cli_runner.invoke(commands, init_cmd, obj=metadata)
+    override_path = metadata.project_path / "conf" / "sub_pipeline"/ "base" / "databricks.yml"
+    assert result.exit_code == 0, (result.exit_code, result.stdout)
+    assert metadata.project_path.exists(), "Project path not created"
+    assert metadata.project_path.is_dir(), "Project path is not a directory"
+    assert override_path.exists(), "Override file not created"
+
+    deploy_cmd = ["databricks", "deploy", "--bundle", "--debug", "--conf=conf/sub_pipeline"]
     result = cli_runner.invoke(commands, deploy_cmd, obj=metadata)
     assert result.exit_code == 0, (result.exit_code, result.stdout)


### PR DESCRIPTION
Default value is `conf`.

This PR is to give the ability to the user to specify a custom path for the `conf` folder, for example `conf/sub_pipeline` when working with several independent pipelines in the same repo.