### PR TITLE
Update exception when databricks-cli

### DIFF
--- a/src/kedro_databricks/init.py
+++ b/src/kedro_databricks/init.py
@@ -160,7 +160,7 @@ def write_bundle_template(metadata: ProjectMetadata):
     project_path = metadata.project_path
     log = logging.getLogger(package_name)
     if shutil.which("databricks") is None:  # pragma: no cover
-        raise Exception("databricks CLI is not installed")
+        raise Exception("databricks CLI is not installed, you can find the installation guide here: https://docs.databricks.com/en/dev-tools/cli/install.html")
 
     config = {
         "project_name": package_name,


### PR DESCRIPTION
# Context
Address #60 

Part of the confusion is that `databricks-cli` used to be a Python package, so I though it's missing from the dependencies. I have found out later it's no longer a python package so it needed to be installed separately. I thought it would be nice to not just throw an error about CLI not installed, but also guide what's the next step for user.


