### PR TITLE
refactor(bundle): sort task dependencies

### DIFF
--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -219,6 +219,7 @@ class BundleController:
             entry_point = "databricks_run"
             params = params + ["--package-name", self.package_name]
 
+        depends_on = sorted(list(depends_on), key=lambda dep: dep.name)
         task = {
             "task_key": name.replace(".", "_"),
             "libraries": [{"whl": "../dist/*.whl"}],

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -209,6 +209,14 @@ def test_generate_workflow(metadata):
     assert controller._create_workflow("workflow1", pipeline) == WORKFLOW
 
 
+def test_create_task(metadata):
+    controller = BundleController(metadata, "fake_env", "conf")
+    expected_task = _generate_task("task", ["a", "b"])
+    assert controller._create_task("task", [
+        node(identity, ["input"], ["output"], name="b"),
+        node(identity, ["input"], ["output"], name="a")]) == expected_task
+
+
 def test_generate_resources(metadata):
     controller = BundleController(metadata, "fake_env", "conf")
     controller.pipelines = {"__default__": Pipeline([])}


### PR DESCRIPTION
Sort the task dependencies to avoid generating noise when updating the bundle of an existing pipeline.