### PR TITLE
refactor(bundle): use named_parameters rather than parameters

### DIFF
--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -225,13 +225,12 @@ class BundleController:
             # We need to pass something like `["--params", "key1=value1,key2=value2"]`
             params = params + ["--params", _join_runtime_parameters(self.runtime_params)]
 
-        depends_on = sorted(list(depends_on), key=lambda dep: dep.name)
         task = {
             "task_key": name.replace(".", "_"),
             "libraries": [{"whl": "../dist/*.whl"}],
             "depends_on": [
                 {"task_key": dep.name.replace(".", "_")}
-                for dep in sorted(list(depends_on), key=lambda dep: dep.name)
+                for dep in sorted(depends_on, key=lambda dep: dep.name)
             ],
             "python_wheel_task": {
                 "package_name": self.package_name,

--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import logging
 from collections.abc import Iterable, MutableMapping
 from pathlib import Path
@@ -26,7 +27,7 @@ from kedro_databricks.utils.override_resources import override_resources
 
 class BundleController:
     def __init__(
-        self, metadata: ProjectMetadata, env: str, config_dir: str = "conf"
+        self, metadata: ProjectMetadata, env: str, config_dir: str = "conf", runtime_params: str | None = None
     ) -> None:
         """Create a new instance of the BundleController.
 
@@ -47,6 +48,11 @@ class BundleController:
         self.remote_conf_dir: str = "${workspace.file_path}/" + config_dir
         self.local_conf_dir: Path = self.metadata.project_path / config_dir / env
         self.conf: dict[str, Any] = self._load_env_config(MSG="Loading configuration")
+        if runtime_params is not None:
+            self.runtime_params = runtime_params.split(" ")
+            assert len(self.runtime_params) % 2 == 0, f"There should be an even number of runtime_params, got {self.runtime_params}"
+        else:
+            self.runtime_params = None
 
     def _workflows_to_resources(
         self, workflows: dict[str, dict[str, Any]], MSG: str = ""
@@ -214,6 +220,12 @@ class BundleController:
         if require_databricks_run_script():  # pragma: no cover
             entry_point = "databricks_run"
             params = params + ["--package-name", self.package_name]
+
+        if self.runtime_params:
+            # We need to pass something like `["--params", "key1=value1,key2=value2"]`
+            params = params + ["--params", _join_runtime_parameters(self.runtime_params)]
+
+        depends_on = sorted(list(depends_on), key=lambda dep: dep.name)
         task = {
             "task_key": name.replace(".", "_"),
             "libraries": [{"whl": "../dist/*.whl"}],
@@ -258,3 +270,17 @@ class BundleController:
                 yaml.dump(
                     resource, f, default_flow_style=False, indent=4, sort_keys=False
                 )
+
+
+def _join_runtime_parameters(runtime_params: list[str]):
+    return ",".join(["=" .join(pair) for pair in _batched(runtime_params, 2)])
+
+
+def _batched(iterable, n):
+    "Batch data into tuples of length n. The last batch may be shorter."
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    if n < 1:
+        raise ValueError('n must be at least one')
+    it = iter(iterable)
+    while batch := tuple(itertools.islice(it, n)):
+        yield batch

--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -48,13 +48,7 @@ class BundleController:
         self.remote_conf_dir: str = "${workspace.file_path}/" + config_dir
         self.local_conf_dir: Path = self.metadata.project_path / config_dir / env
         self.conf: dict[str, Any] = self._load_env_config(MSG="Loading configuration")
-        if runtime_params is not None:
-            self.runtime_params = runtime_params.split(" ")
-            assert len(self.runtime_params) % 2 == 0, f"There should be an even number of runtime_params, got {self.runtime_params}"
-            # We need to pass to kedro in argument like `["--params", "key1=value1,key2=value2"]`
-            self.runtime_params = _join_runtime_parameters(self.runtime_params)
-        else:
-            self.runtime_params = None
+        self.runtime_params = runtime_params
 
     def _workflows_to_resources(
         self, workflows: dict[str, dict[str, Any]], MSG: str = ""
@@ -270,17 +264,3 @@ class BundleController:
                 yaml.dump(
                     resource, f, default_flow_style=False, indent=4, sort_keys=False
                 )
-
-
-def _join_runtime_parameters(runtime_params: list[str]):
-    return ",".join(["=".join(pair) for pair in _batched(runtime_params, 2)])
-
-
-def _batched(iterable, n):
-    "Batch data into tuples of length n. The last batch may be shorter."
-    # batched('ABCDEFG', 3) --> ABC DEF G
-    if n < 1:
-        raise ValueError('n must be at least one')
-    it = iter(iterable)
-    while batch := tuple(itertools.islice(it, n)):
-        yield batch

--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -272,7 +272,7 @@ class BundleController:
 
 
 def _join_runtime_parameters(runtime_params: list[str]):
-    return ",".join(["=" .join(pair) for pair in _batched(runtime_params, 2)])
+    return ",".join(["=".join(pair) for pair in _batched(runtime_params, 2)])
 
 
 def _batched(iterable, n):

--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -51,6 +51,8 @@ class BundleController:
         if runtime_params is not None:
             self.runtime_params = runtime_params.split(" ")
             assert len(self.runtime_params) % 2 == 0, f"There should be an even number of runtime_params, got {self.runtime_params}"
+            # We need to pass to kedro in argument like `["--params", "key1=value1,key2=value2"]`
+            self.runtime_params = _join_runtime_parameters(self.runtime_params)
         else:
             self.runtime_params = None
 
@@ -222,8 +224,7 @@ class BundleController:
             params = params + ["--package-name", self.package_name]
 
         if self.runtime_params:
-            # We need to pass something like `["--params", "key1=value1,key2=value2"]`
-            params = params + ["--params", _join_runtime_parameters(self.runtime_params)]
+            params = params + ["--params", self.runtime_params]
 
         task = {
             "task_key": name.replace(".", "_"),

--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import logging
 from collections.abc import Iterable, MutableMapping
 from pathlib import Path

--- a/src/kedro_databricks/plugin.py
+++ b/src/kedro_databricks/plugin.py
@@ -74,6 +74,7 @@ def init(
 @click.option("-e", "--env", default=DEFAULT_TARGET, help=ENV_HELP)
 @click.option("-c", "--conf", default=DEFAULT_CONF_FOLDER, help=CONF_HELP)
 @click.option("-p", "--pipeline", default=None, help="Bundle a single pipeline")
+@click.option("-r", "--runtime-params", default=None, help="Kedro run time params")
 @click.option(
     "--overwrite",
     default=False,
@@ -88,6 +89,7 @@ def bundle(
     env: str,
     conf: str,
     pipeline: str | None,
+    runtime_params: str | None,
     overwrite: bool,
 ):
     """Convert kedro pipelines into Databricks asset bundle resources"""
@@ -97,7 +99,7 @@ def bundle(
         )
 
     MSG = "Create Asset Bundle Resources"
-    controller = BundleController(metadata, env, conf)
+    controller = BundleController(metadata, env, conf, runtime_params)
     resources = controller.generate_resources(pipeline, MSG)
     bundle_resources = controller.apply_overrides(resources, default_key)
     controller.save_bundled_resources(bundle_resources, overwrite)
@@ -113,6 +115,7 @@ def bundle(
 )
 @click.option("-c", "--conf", default=DEFAULT_CONF_FOLDER, help=CONF_HELP)
 @click.option("-p", "--pipeline", default=None, help="Bundle a single pipeline")
+@click.option("-r", "--runtime-params", default=None, help="Kedro run time params")
 @click.argument("databricks_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_obj
 def deploy(
@@ -121,6 +124,7 @@ def deploy(
     bundle: bool,
     conf: str,
     pipeline: str,
+    runtime_params: str | None,
     databricks_args: list[str],
 ):
     """Deploy the asset bundle to Databricks
@@ -134,7 +138,7 @@ def deploy(
     controller.validate_databricks_config()
     controller.build_project()
     if bundle is True:
-        bundle_controller = BundleController(metadata, env, conf)
+        bundle_controller = BundleController(metadata, env, conf, runtime_params)
         workflows = bundle_controller.generate_resources(pipeline)
         bundle_resources = bundle_controller.apply_overrides(
             workflows, DEFAULT_CONFIG_KEY

--- a/src/kedro_databricks/plugin.py
+++ b/src/kedro_databricks/plugin.py
@@ -74,7 +74,7 @@ def init(
 @click.option("-e", "--env", default=DEFAULT_TARGET, help=ENV_HELP)
 @click.option("-c", "--conf", default=DEFAULT_CONF_FOLDER, help=CONF_HELP)
 @click.option("-p", "--pipeline", default=None, help="Bundle a single pipeline")
-@click.option("-r", "--runtime-params", default=None, help="Kedro run time params")
+@click.option("-r", "--runtime-params", default=None, help="Kedro run time params in `key1=value1,key2=value2` format")
 @click.option(
     "--overwrite",
     default=False,
@@ -115,7 +115,7 @@ def bundle(
 )
 @click.option("-c", "--conf", default=DEFAULT_CONF_FOLDER, help=CONF_HELP)
 @click.option("-p", "--pipeline", default=None, help="Bundle a single pipeline")
-@click.option("-r", "--runtime-params", default=None, help="Kedro run time params")
+@click.option("-r", "--runtime-params", default=None, help="Kedro run time params in `key1=value1,key2=value2` format")
 @click.argument("databricks_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_obj
 def deploy(

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -261,4 +261,5 @@ def test_databricks_bundle_with_runtime_params(kedro_project, cli_runner, metada
             for j, param in enumerate(params):
                 if param == "--params":
                     assert params[j + 1] == "run_date={{job.parameters.run_date}},run_id={{job.parameters.run_id}}"
+                    break
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -199,3 +199,66 @@ def test_databricks_bundle_without_overrides(kedro_project, cli_runner, metadata
             for j, param in enumerate(params):
                 if param == "--env":
                     assert params[j + 1] == "dev"
+
+
+def test_databricks_bundle_with_runtime_params(kedro_project, cli_runner, metadata):
+    """Test the `bundle` command"""
+
+    init_cmd = ["databricks", "init", "--provider", "aws"]
+    result = cli_runner.invoke(commands, init_cmd, obj=metadata)
+    assert result.exit_code == 0, (result.exit_code, result.stdout)
+    assert metadata.project_path.exists(), "Project path not created"
+    assert metadata.project_path.is_dir(), "Project path is not a directory"
+    assert metadata.project_path / "databricks.yml", "Databricks config not created"
+
+    databricks_config = _read_databricks_config(metadata.project_path)
+    targets = _get_targets(databricks_config)
+    for target in targets:
+        override_path = metadata.project_path / "conf" / target / "databricks.yml"
+        assert (
+            override_path.exists()
+        ), f"Resource Overrides at {override_path} does not exist"
+
+    command = ["databricks", "bundle", "--env", "dev", "--runtime-params", "run_date {{job.parameters.run_date}} run_id {{job.parameters.run_id}}"]
+    result = cli_runner.invoke(commands, command, obj=metadata)
+    resource_dir = kedro_project / "resources"
+    conf_dir = kedro_project / "conf" / "dev"
+    assert result.exit_code == 0, (result.exit_code, result.stdout)
+    assert resource_dir.exists(), "Resource directory not created"
+    assert resource_dir.is_dir(), "Resource directory is not a directory"
+    assert conf_dir.exists(), "Configuration directory not created"
+
+    files = [p.name for p in resource_dir.rglob("*")]
+    files.sort()
+    assert files == [
+        f"{metadata.package_name}.yml",
+        f"{metadata.package_name}_ds.yml",
+    ], f"Resource files not created: {', '.join(files)}"
+
+    resources = []
+    for p in files:
+        with open(resource_dir / p) as f:
+            resource = yaml.safe_load(f)
+            resources.append(resource)
+
+    for resource, file_name in zip(resources, files):
+        assert resource.get("resources") is not None
+
+        jobs = resource["resources"]["jobs"]
+        assert len(jobs) == 1
+
+        job = jobs.get(file_name.split(".")[0])
+        assert job is not None
+
+        tasks = job.get("tasks")
+        assert tasks is not None
+        assert len(tasks) == 5
+
+        for i, task in enumerate(tasks):
+            assert task.get("task_key") == f"node{i}"
+            params = task.get("python_wheel_task").get("parameters")
+            assert "--params" in params
+            for j, param in enumerate(params):
+                if param == "--params":
+                    assert params[j + 1] == "run_date={{job.parameters.run_date}},run_id={{job.parameters.run_id}}"
+

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -219,7 +219,7 @@ def test_databricks_bundle_with_runtime_params(kedro_project, cli_runner, metada
             override_path.exists()
         ), f"Resource Overrides at {override_path} does not exist"
 
-    command = ["databricks", "bundle", "--env", "dev", "--runtime-params", "run_date {{job.parameters.run_date}} run_id {{job.parameters.run_id}}"]
+    command = ["databricks", "bundle", "--env", "dev", "--runtime-params", "run_date={{job.parameters.run_date}},run_id={{job.parameters.run_id}}"]
     result = cli_runner.invoke(commands, command, obj=metadata)
     resource_dir = kedro_project / "resources"
     conf_dir = kedro_project / "conf" / "dev"

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import pytest
 from kedro.pipeline import Pipeline, node
 
-from kedro_databricks.bundle import BundleController, _batched, _join_runtime_parameters
+from kedro_databricks.bundle import BundleController
 from kedro_databricks.utils.common import require_databricks_run_script
 
 
@@ -89,11 +88,6 @@ def generate_workflow(conf="conf"):
 WORKFLOW = generate_workflow()
 
 
-def test_bundle_controller_with_runtime_params_raise(metadata):
-    with pytest.raises(AssertionError):
-        BundleController(metadata, "fake_env", "conf", runtime_params="key1 value1 key2 value2 param3")
-
-
 def test_generate_workflow(metadata):
     controller = BundleController(metadata, "fake_env", "conf")
     assert controller._create_workflow("workflow1", pipeline) == WORKFLOW
@@ -117,7 +111,7 @@ def test_create_task(metadata):
 
 
 def test_create_task_with_runtime_params(metadata):
-    controller = BundleController(metadata, "fake_env", "conf", runtime_params="key1 value1 key2 value2")
+    controller = BundleController(metadata, "fake_env", "conf", runtime_params="key1=value1,key2=value2")
     expected_task = _generate_task("task", ["a", "b"], runtime_params="key1=value1,key2=value2")
     node_a = node(identity, ["input"], ["output"], name="a")
     node_b = node(identity, ["input"], ["output"], name="b")

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -257,12 +257,3 @@ def test_save_resoureces(metadata):
     assert (
         project_resources.exists()
     ), f"Failed to save project resources, {project_files}"
-
-
-def test_join_runtime_parameters():
-    assert _join_runtime_parameters(["key1", "value1", "key2", "value2", "param3"]) == "key1=value1,key2=value2,param3"
-
-
-def test_batched():
-    assert list(_batched([1, 2, 3, 4], 2)) == [(1, 2), (3, 4)]
-    assert list(_batched([1, 2, 3, 4, 5], 3)) == [(1, 2, 3), (4, 5)]

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import pytest
 from kedro.pipeline import Pipeline, node
 
-from kedro_databricks.bundle import BundleController
+from kedro_databricks.bundle import BundleController, _batched, _join_runtime_parameters
 from kedro_databricks.utils.common import require_databricks_run_script
 
 
@@ -33,7 +34,7 @@ pipeline = Pipeline(
 )
 
 
-def _generate_task(task_key: int | str, depends_on: list[str] = [], conf: str = "conf"):
+def _generate_task(task_key: int | str, depends_on: list[str] = [], conf: str = "conf", runtime_params: str = None):
     entry_point = "fake-project"
     params = [
         "--nodes",
@@ -47,6 +48,9 @@ def _generate_task(task_key: int | str, depends_on: list[str] = [], conf: str = 
     if require_databricks_run_script():
         entry_point = "databricks_run"
         params = params + ["--package-name", "fake_project"]
+
+    if runtime_params:
+        params = params + ["--params", runtime_params]
 
     task = {
         "task_key": task_key,
@@ -85,6 +89,11 @@ def generate_workflow(conf="conf"):
 WORKFLOW = generate_workflow()
 
 
+def test_bundle_controller_with_runtime_params_raise(metadata):
+    with pytest.raises(AssertionError):
+        BundleController(metadata, "fake_env", "conf", runtime_params="key1 value1 key2 value2 param3")
+
+
 def test_generate_workflow(metadata):
     controller = BundleController(metadata, "fake_env", "conf")
     assert controller._create_workflow("workflow1", pipeline) == WORKFLOW
@@ -93,6 +102,23 @@ def test_generate_workflow(metadata):
 def test_create_task(metadata):
     controller = BundleController(metadata, "fake_env", "conf")
     expected_task = _generate_task("task", ["a", "b"])
+    node_a = node(identity, ["input"], ["output"], name="a")
+    node_b = node(identity, ["input"], ["output"], name="b")
+    assert (
+        controller._create_task(
+            "task",
+            [
+                node_b,
+                node_a,
+            ],
+        )
+        == expected_task
+    )
+
+
+def test_create_task_with_runtime_params(metadata):
+    controller = BundleController(metadata, "fake_env", "conf", runtime_params="key1 value1 key2 value2")
+    expected_task = _generate_task("task", ["a", "b"], runtime_params="key1=value1,key2=value2")
     node_a = node(identity, ["input"], ["output"], name="a")
     node_b = node(identity, ["input"], ["output"], name="b")
     assert (
@@ -231,3 +257,12 @@ def test_save_resoureces(metadata):
     assert (
         project_resources.exists()
     ), f"Failed to save project resources, {project_files}"
+
+
+def test_join_runtime_parameters():
+    assert _join_runtime_parameters(["key1", "value1", "key2", "value2", "param3"]) == "key1=value1,key2=value2,param3"
+
+
+def test_batched():
+    assert list(_batched([1, 2, 3, 4], 2)) == [(1, 2), (3, 4)]
+    assert list(_batched([1, 2, 3, 4, 5], 3)) == [(1, 2, 3), (4, 5)]


### PR DESCRIPTION
Give the ability to define kedro runtime parameters.


The purpose of this change is to benefit of making job parameters available as task parameters:

<img width="830" alt="Screenshot 2025-01-16 at 23 28 35" src="https://github.com/user-attachments/assets/f5bb99dc-e94a-41fc-9a15-d5222d87ef74" />
https://docs.databricks.com/en/jobs/task-parameters.html

Using job parameters as task parameters would give the ability to define a `params` argument at the databricks job level that would be passed from the databricks  job to the databricks tasks and so it would give the ability to use the kedro `runtime_params:` resolver.