### PR TITLE
Remove deprecated format from bundle definition

### DIFF
--- a/src/kedro_databricks/bundle.py
+++ b/src/kedro_databricks/bundle.py
@@ -196,7 +196,6 @@ class BundleController:
                 self._create_task(node.name, depends_on=deps)
                 for node, deps in sorted(pipeline.node_dependencies.items())
             ],
-            "format": "MULTI_TASK",
         }
 
         return _remove_nulls_from_dict(_sort_dict(workflow, WORKFLOW_KEY_ORDER))
@@ -347,8 +346,6 @@ def _apply_overrides(
         overrides.get("environments", []),
         "environment_key",
     )
-
-    workflow["format"] = "MULTI_TASK"
 
     return _remove_nulls_from_dict(_sort_dict(workflow, WORKFLOW_KEY_ORDER))
 

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -81,7 +81,6 @@ def generate_workflow(conf="conf"):
     return {
         "name": "workflow1",
         "tasks": tasks,
-        "format": "MULTI_TASK",
     }
 
 
@@ -236,7 +235,6 @@ def test_generate_resources(metadata):
             "resources": {
                 "jobs": {
                     "fake_project": {
-                        "format": "MULTI_TASK",
                         "name": "fake_project",
                         "tasks": [
                             _generate_task("node"),
@@ -259,7 +257,6 @@ def test_generate_resources_another_conf(metadata):
             "resources": {
                 "jobs": {
                     "fake_project": {
-                        "format": "MULTI_TASK",
                         "name": "fake_project",
                         "tasks": [
                             _generate_task("node", conf="sub_conf"),
@@ -286,7 +283,6 @@ def test_generate_resources_in_a_sorted_manner(metadata):
             "resources": {
                 "jobs": {
                     "fake_project": {
-                        "format": "MULTI_TASK",
                         "name": "fake_project",
                         "tasks": [
                             _generate_task("a_node"),
@@ -325,7 +321,6 @@ def test_generate_resources_for_a_single_pipeline(metadata):
             "resources": {
                 "jobs": {
                     "fake_project_b_pipeline": {
-                        "format": "MULTI_TASK",
                         "name": "fake_project_b_pipeline",
                         "tasks": [
                             _generate_task("b_node"),


### PR DESCRIPTION
The latest version of the [Databricks Jobs API ](https://docs.databricks.com/api/workspace/jobs/create#format) shows that the `format` key is deprecated and the value will be ignored in create requests. So, I made a tiny PR to remove this from the bundle definitions and unit tests.