### PR TITLE
fix: minor bugs in bundle

### DIFF
--- a/src/kedro_databricks/cli/bundle/generate_resources.py
+++ b/src/kedro_databricks/cli/bundle/generate_resources.py
@@ -38,7 +38,7 @@ class ResourceGenerator:
         self.metadata = metadata
         self.env = env
         self.pipelines: MutableMapping = pipelines
-        self.remote_conf_dir = f"/Workspace/${{workspace.file_path}}/{conf_source}"
+        self.remote_conf_dir = f"/${{workspace.file_path}}/{conf_source}"
         self.params = params
 
     def generate_resources(

--- a/src/kedro_databricks/cli/bundle/utils.py
+++ b/src/kedro_databricks/cli/bundle/utils.py
@@ -66,7 +66,7 @@ def get_entry_point(project_name: str) -> str:
     """
     entrypoint = project_name.strip().lower()
     entrypoint = re.sub(r" +", " ", entrypoint)
-    entrypoint = re.sub(r"[^a-zA-Z]", "-", entrypoint)
+    entrypoint = re.sub(r"[^a-zA-Z_]", "-", entrypoint)
     entrypoint = re.sub(r"(-+)$", "", entrypoint)
     entrypoint = re.sub(r"^(-+)", "", entrypoint)
     return entrypoint


### PR DESCRIPTION
This pull request makes two targeted improvements: it corrects a path used for remote configuration directories and updates the logic for generating entry point names to allow underscores. These changes enhance compatibility and correctness in resource path handling and project naming.

**Resource path correction:**

* Updated the format of `remote_conf_dir` in `generate_resources.py` to remove the `/Workspace` prefix, ensuring the path is constructed as `/${workspace.file_path}/{conf_source}`.

**Entry point naming logic:**

* Modified the regular expression in `get_entry_point` (in `utils.py`) to allow underscores in project names, replacing only non-alphabetic and non-underscore characters with hyphens.