### PR TITLE
ci: external contributors are not allowed to post PR comment in gh ac…

### DIFF
--- a/.github/workflows/post_comment.yml
+++ b/.github/workflows/post_comment.yml
@@ -1,0 +1,80 @@
+name: Post comments
+
+on:
+  workflow_run:
+    workflows: ["Unit tests"]
+    types:
+      - completed
+
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip pr.zip
+
+      - name: 'Export Issue number'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            const core = require('@actions/core');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            core.exportVariable('ISSUE_NUMBER', issue_number);
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "*/**/coverage-*.xml"
+
+      - name: 'Post changelog comment'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            var body = fs.readFileSync('./body.md').toString();
+            if (body.length == 0) {
+              body = "## Changelog\nNo version increment detected.";
+            }
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: body
+            });

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,34 +18,64 @@ jobs:
         kedro_version: ["0.19.7", "0.19.8"]
     steps:
       - uses: actions/checkout@v4
+
       - uses: databricks/setup-cli@main
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Sync kedro-databricks
         run: |
           uv add "kedro==${{ matrix.kedro_version }}"
           uv sync --no-group test
+
       - name: Lint kedro-databricks
         run: uv run ruff check
+
       - name: Test kedro-databricks
         run: uv run pytest tests/unit
-      - name: Coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
+
+      - name: Rename coverage file
+        run: mv coverage.xml coverage-${{ matrix.kedro_version }}-${{ matrix.python-version }}.xml
+
+      - uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ github.token }}
-          title: "Unit Test Coverage Report"
-          pytest-xml-coverage-path: "coverage.xml"
-  version:
-    name: Check for changes and post bump comment
+          name: coverage-${{ matrix.kedro_version }}-${{ matrix.python-version }}
+          path: coverage-${{ matrix.kedro_version }}-${{ matrix.python-version }}.xml
+          if-no-files-found: ignore
+  build-pr:
+    name: Build PR artifact
     runs-on: ubuntu-latest
     needs: test
     steps:
       - uses: actions/checkout@v4
-      - name: Check Version
-        uses: ./.github/actions/check_version
+
+      - uses: actions/download-artifact@v5
         with:
-          github_token: ${{ github.token }}
+          pattern: coverage-*
+          path: coverage
+          merge-multiple: true
+
+      - name: Create changelog
+        id: cz
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          changelog_increment_filename: body.md
           push: false
-          pr_number: ${{ github.event.pull_request.number }}
+
+      - name: Create PR artifact
+        run: |
+          mkdir -p ./pr
+          cp -r coverage ./pr/coverage
+          cp body.md ./pr/body.md
+          cp ${{ github.event_path }} ./pr/event.json
+          echo ${{ github.event.pull_request.number }} > ./pr/NR
+          ls -la ./pr
+
+      - name: Upload PR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: pr/

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ wheels = [
 
 [[package]]
 name = "kedro-databricks"
-version = "0.12.4"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "databricks-sdk" },


### PR DESCRIPTION
This pull request introduces a new workflow for posting comments on pull requests and refactors the existing unit test workflow to improve automation and reporting. The main changes include adding a dedicated workflow for posting coverage and changelog comments, and updating the unit test workflow to generate and upload artifacts for use in comment posting.

**Workflow automation and reporting improvements:**

* Added a new workflow `.github/workflows/post_comment.yml` that automatically posts coverage and changelog comments to pull requests after unit tests complete successfully. This workflow handles artifact download, extraction, and posting comments using GitHub Actions and custom scripts.
* Refactored `.github/workflows/unit_tests.yml` to remove direct posting of coverage comments and changelog bump notifications. Instead, it now generates artifacts (`coverage.xml`, `body.md`, and PR number) and uploads them for use by the new comment posting workflow.
* Integrated `commitizen-action` to automate changelog generation and artifact creation, streamlining the process and ensuring consistency in changelog comments.