### PR TITLE
fix: package name should not be prefixed when using --pipeline

### DIFF
--- a/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
@@ -40,6 +40,11 @@ class AbstractResourceGenerator(ABC):
     for each according to the Databricks REST API
     """
 
+    @abstractmethod
+    def _create_job_dict(
+        self, name: str, pipeline: Pipeline, pipeline_name: str
+    ) -> dict[str, Any]: ...
+
     def __init__(
         self,
         metadata: ProjectMetadata,
@@ -73,45 +78,56 @@ class AbstractResourceGenerator(ABC):
         if pipeline_name and pipeline:
             log.info(f"Generating resources for pipeline '{pipeline_name}'")
             name = self._make_job_name(self.metadata.package_name, pipeline_name)
-            jobs[name] = self._create_job(name=name, pipeline=pipeline)
+            jobs[name] = self._create_job(
+                name=name,
+                pipeline=pipeline,
+                pipeline_name=pipeline_name,
+            )
             return jobs
         if pipeline_name:
             raise KeyError(
                 f"Pipeline '{pipeline_name}' not found. Available pipelines: {list(self.pipelines.keys())}"
             )
 
-        for pipe_name, pipeline in self.pipelines.items():
-            if len(pipeline.nodes) == 0:
+        for registered_pipeline_name, registered_pipeline in self.pipelines.items():
+            if len(registered_pipeline.nodes) == 0:
                 continue
-            name = self._make_job_name(self.metadata.package_name, pipe_name)
-            job = self._create_job(name=name, pipeline=pipeline)
+            name = self._make_job_name(
+                self.metadata.package_name, registered_pipeline_name
+            )
+            job = self._create_job(
+                name=name,
+                pipeline=registered_pipeline,
+                pipeline_name=registered_pipeline_name,
+            )
             log.debug(f"Job '{name}' successfully created.")
             log.debug(job)
             jobs[name] = job
 
         return jobs
 
-    def _create_job(self, name: str, pipeline: Pipeline) -> dict[str, Any]:
+    def _create_job(
+        self, name: str, pipeline: Pipeline, pipeline_name: str
+    ) -> dict[str, Any]:
         """Create a Databricks job for a given pipeline.
 
         Args:
             name (str): name of the pipeline
             pipeline (Pipeline): Kedro pipeline object
-            env (str): name of the env to be used by the tasks of the job
+            pipeline_name (str): name of the pipeline
 
         Returns:
             Dict[str, Any]: a Databricks job
         """
         ## Follows the Databricks REST API schema
         ## https://docs.databricks.com/api/workspace/jobs/create
-        job = self._create_job_dict(name=name, pipeline=pipeline)
+        job = self._create_job_dict(
+            name=name, pipeline=pipeline, pipeline_name=pipeline_name
+        )
         non_null = remove_nulls(sort_dict(job, JOB_KEY_ORDER))
         if not isinstance(non_null, dict):  # pragma: no cover - this is a type check
             raise RuntimeError("Expected a dict")
         return non_null
-
-    @abstractmethod
-    def _create_job_dict(self, name: str, pipeline: Pipeline) -> dict[str, Any]: ...
 
     def _create_task_with_params(
         self,

--- a/src/kedro_databricks/utilities/resource_generator/node_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/node_resource_generator.py
@@ -18,12 +18,15 @@ from kedro_databricks.utilities.resource_generator.abstract_resource_generator i
 class NodeResourceGenerator(AbstractResourceGenerator):
     """Generate a job with one Databricks task per Kedro node."""
 
-    def _create_job_dict(self, name: str, pipeline: Pipeline) -> dict[str, Any]:
+    def _create_job_dict(
+        self, name: str, pipeline: Pipeline, pipeline_name: str
+    ) -> dict[str, Any]:  # noqa: ARG002
         """Build the job payload for a node-based job.
 
         Args:
             name (str): The job name.
             pipeline (Pipeline): The Kedro pipeline to convert.
+            pipeline_name (str): Unused parameter for compatibility with the abstract method.
 
         Returns:
             dict[str, Any]: A Databricks job payload containing per-node tasks.

--- a/src/kedro_databricks/utilities/resource_generator/pipeline_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/pipeline_resource_generator.py
@@ -16,17 +16,30 @@ from kedro_databricks.utilities.resource_generator.abstract_resource_generator i
 class PipelineResourceGenerator(AbstractResourceGenerator):
     """Generate a job with a single task for the whole pipeline."""
 
-    def _create_job_dict(self, name: str, pipeline: Pipeline) -> dict[str, Any]:
+    def _create_job_dict(
+        self,
+        name: str,
+        pipeline: Pipeline,
+        pipeline_name: str,  # noqa: ARG002
+    ) -> dict[str, Any]:
         """Build the job payload for a pipeline-based job.
 
         Args:
             name (str): The job name.
-            pipeline (Pipeline): The Kedro pipeline to run as a single task.
+            pipeline (Pipeline): Unused parameter for compatibility with the abstract method.
+            pipeline_name (str): The name of the pipeline.
 
         Returns:
             dict[str, Any]: A Databricks job payload containing one task.
         """
-        return {"name": name, "tasks": [self._create_pipeline_task(name)]}
+        if pipeline_name is None:
+            raise ValueError(
+                "Pipeline name must be provided to create a job dict when --pipeline is used."
+            )
+        return {
+            "name": name,
+            "tasks": [self._create_pipeline_task(pipeline_name)],
+        }
 
     def _create_pipeline_task(self, name: str) -> dict[str, Any]:
         """Create the single task that executes the full pipeline.

--- a/tests/unit/test_utilities_resource_generators.py
+++ b/tests/unit/test_utilities_resource_generators.py
@@ -10,12 +10,12 @@ from tests.utils import JOB, _generate_task, identity, long_identity, node, pipe
 
 def test_create_job(metadata):
     g = NodeResourceGenerator(metadata, "fake_env")
-    assert g._create_job("job1", pipeline) == JOB
+    assert g._create_job("job1", pipeline, "__default__") == JOB
 
 
 def test_create_job_pipeline(metadata):
     g = PipelineResourceGenerator(metadata, "fake_env")
-    assert g._create_job("job1", pipeline) is not None
+    assert g._create_job("job1", pipeline, "__default__") is not None
 
 
 def test_create_task(metadata):


### PR DESCRIPTION
This pull request refactors the resource generator classes to ensure that the pipeline name is explicitly passed and handled when creating Databricks job definitions. This change improves clarity and correctness, especially when generating jobs for specific pipelines, and enforces that the pipeline name is always available where needed.

Key changes by theme:

**Resource generator API changes:**
* Updated the abstract method `_create_job_dict` in `AbstractResourceGenerator` to require a `pipeline_name` parameter, ensuring all subclasses implement this signature.
* Refactored the `_create_job` method and its usage in `AbstractResourceGenerator` to pass the `pipeline_name` argument throughout job creation logic.

**Subclass implementations:**
* Modified `NodeResourceGenerator` and `PipelineResourceGenerator` to update their `_create_job_dict` methods to accept the new `pipeline_name` parameter, with appropriate handling and documentation. [[1]](diffhunk://#diff-16722864080fa25671ac497fbcf36bab7eb3e99b8bd80d4b85cecbc3dac84ca1L21-R29) [[2]](diffhunk://#diff-599a5df801d58b11206de06bca77f93fa002ee520d09c6b2233ad983427bfedeL19-R42)
* In `PipelineResourceGenerator`, added a check to raise a `ValueError` if `pipeline_name` is not provided, ensuring correctness when creating a job dict.

**Tests:**
* Updated unit tests to provide the required `pipeline_name` argument when calling `_create_job`, maintaining test coverage and correctness.