### PR TITLE
Fix/path replacement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ addopts = [
     '--junit-xml=coverage.junit.xml',
     '--cov=kedro_databricks',
     '--no-cov-on-fail',
+    '--cov-fail-under=1',
     '--ignore-glob="develop-eggs/*"',
     '-ra',
     '-vv',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ addopts = [
     '--junit-xml=coverage.junit.xml',
     '--cov=kedro_databricks',
     '--no-cov-on-fail',
-    '--cov-fail-under=70',
     '--ignore-glob="develop-eggs/*"',
     '-ra',
     '-vv',

--- a/scripts/mkdev.py
+++ b/scripts/mkdev.py
@@ -86,6 +86,8 @@ def new(project_name: str, project_path: Path, overwrite: bool = False):
             "databricks-iris",
             "--name",
             project_name,
+            "--checkout",
+            "main",
         ],
         check=False,
     )

--- a/src/kedro_databricks/commands/bundle.py
+++ b/src/kedro_databricks/commands/bundle.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any
 
 import click
@@ -21,10 +22,24 @@ from kedro_databricks.constants import (
     DEFAULT_ENV,
 )
 from kedro_databricks.utilities.logger import get_logger
-from kedro_databricks.utilities.resource_generator import RESOURCE_GENERATOR_RESOLVER
+from kedro_databricks.utilities.resource_generator import (
+    RESOURCE_GENERATOR_RESOLVER,
+    AbstractResourceGenerator,
+)
 from kedro_databricks.utilities.resource_overrider import RESOURCE_OVERRIDER_RESOLVER
 
 log = get_logger("bundle")
+
+
+class MemoryDatasetError(Exception):
+    def __init__(
+        self, klass: AbstractResourceGenerator, undeclared_datasets: Iterable[str]
+    ) -> None:
+        resource_line = ", ".join(undeclared_datasets)
+        msg = f"""Resource Generator of type {klass.__class__.__name__} does not support MemoryDatasets.
+The following inputs/outputs are not specified in your catalog: {resource_line}
+If This is intentional, you can use --resource-generator='pipeline' to generate a single job"""
+        super().__init__(msg)
 
 
 @click.command()
@@ -83,12 +98,17 @@ def command(
     overwrite: bool,
 ):
     """Databricks Asset Bundle commands"""
+    local_config_dir = metadata.project_path / conf_source / env
+
+    # If the configuration directory does not exist, Kedro will not load any configuration
+    if not local_config_dir.exists():
+        log.warning(f"Creating {local_config_dir.relative_to(metadata.project_path)}")
+        local_config_dir.mkdir(parents=True)
+
     if default_key.startswith("_"):  # pragma: no cover
         raise ValueError(
             "Default key cannot start with `_` as this is not recognized by OmegaConf."
         )
-
-    ResourceGenerator = RESOURCE_GENERATOR_RESOLVER.resolve(resource_generator)
 
     if not (metadata.project_path / conf_source / env / "databricks.yml").exists():
         raise FileNotFoundError(
@@ -96,49 +116,62 @@ def command(
             f"in '{conf_source}/{env}/databricks.yml'."
         )
 
-    overrides = _load_kedro_env_config(metadata, config_dir=conf_source, env=env)
-    if "resources" not in overrides:
-        raise KeyError(
-            f"'resources' key not found in the 'databricks' configuration for environment '{env}'."
-        )
-
-    g = ResourceGenerator(metadata, env, conf_source, params)
-    all_resources = {"jobs": g.generate_jobs(pipeline)}
-    overridden_resources = {}
-    for resource_type, resource_override_items in overrides["resources"].items():
-        overridden_resources[resource_type] = {}
-        resource_items = all_resources.get(resource_type, {})
-        overrider = RESOURCE_OVERRIDER_RESOLVER.resolve(resource_type)()
-        default_overrides = resource_override_items.pop(default_key, {})
-        regex_overrides = overrider.get_regex_overrides(
-            resource_key=default_key, overrides=resource_override_items
-        )
-        resource_overrides = {
-            k: v
-            for k, v in resource_override_items.items()
-            if not k.startswith("re:") and k != default_key
-        }
-        all_keys = set(resource_items.keys()).union(set(resource_overrides.keys()))
-        for key in all_keys:
-            resource = resource_items.get(key, {})
-            overrides = {
-                default_key: default_overrides,
-                **regex_overrides,
-                **resource_overrides,
-            }
-            overridden_resources[resource_type][key] = overrider.override(
-                resource_key=key,
-                default_key=default_key,
-                resource=resource,
-                overrides=overrides,
+    with KedroSession.create(project_path=metadata.project_path, env=env) as session:
+        overrides = _load_kedro_env_config(session=session)
+        if "resources" not in overrides:
+            raise KeyError(
+                f"'resources' key not found in the 'databricks' configuration for environment '{env}'."
             )
 
-    save_resources(
-        metadata=metadata,
-        env=env,
-        resources=overridden_resources,
-        overwrite=overwrite,
-    )
+        ResourceGenerator = RESOURCE_GENERATOR_RESOLVER.resolve(resource_generator)
+
+        g = ResourceGenerator(
+            session=session,
+            metadata=metadata,
+            conf_source=conf_source,
+            params=params,
+        )
+
+        undeclared_datasets = g.get_memory_datasets()
+        if len(undeclared_datasets) > 0 and not g.can_handle_memory_datasets():
+            raise MemoryDatasetError(g, undeclared_datasets)
+
+        all_resources = {"jobs": g.generate_jobs(pipeline)}
+        overridden_resources = {}
+        for resource_type, resource_override_items in overrides["resources"].items():
+            overridden_resources[resource_type] = {}
+            resource_items = all_resources.get(resource_type, {})
+            overrider = RESOURCE_OVERRIDER_RESOLVER.resolve(resource_type)()
+            default_overrides = resource_override_items.pop(default_key, {})
+            regex_overrides = overrider.get_regex_overrides(
+                resource_key=default_key, overrides=resource_override_items
+            )
+            resource_overrides = {
+                k: v
+                for k, v in resource_override_items.items()
+                if not k.startswith("re:") and k != default_key
+            }
+            all_keys = set(resource_items.keys()).union(set(resource_overrides.keys()))
+            for key in all_keys:
+                resource = resource_items.get(key, {})
+                overrides = {
+                    default_key: default_overrides,
+                    **regex_overrides,
+                    **resource_overrides,
+                }
+                overridden_resources[resource_type][key] = overrider.override(
+                    resource_key=key,
+                    default_key=default_key,
+                    resource=resource,
+                    overrides=overrides,
+                )
+
+        save_resources(
+            metadata=metadata,
+            env=env,
+            resources=overridden_resources,
+            overwrite=overwrite,
+        )
 
 
 def save_resources(
@@ -189,9 +222,7 @@ def save_resources(
                     log.info(f"Wrote {relative_path}")
 
 
-def _load_kedro_env_config(
-    metadata: ProjectMetadata, config_dir: str, env: str
-) -> dict[str, Any]:
+def _load_kedro_env_config(session: KedroSession) -> dict[str, Any]:
     """Load the Databricks configuration for the given environment.
 
     Args:
@@ -202,38 +233,30 @@ def _load_kedro_env_config(
     Returns:
         dict[str, Any]: The Databricks configuration for the given environment
     """
-    local_config_dir = metadata.project_path / config_dir / env
+    config_loader = session._get_config_loader()
+    # Backwards compatibility for ConfigLoader that does not support `config_patterns`
+    if not hasattr(config_loader, "config_patterns"):
+        return config_loader.get("databricks*", "databricks/**")
 
-    # If the configuration directory does not exist, Kedro will not load any configuration
-    if not local_config_dir.exists():
-        log.warning(f"Creating {local_config_dir.relative_to(metadata.project_path)}")
-        local_config_dir.mkdir(parents=True)
+    if not isinstance(config_loader, OmegaConfigLoader):
+        raise TypeError(
+            "Only OmegaConfigLoader is supported to load Databricks configuration."
+        )
 
-    with KedroSession.create(project_path=metadata.project_path, env=env) as session:
-        config_loader = session._get_config_loader()
-        # Backwards compatibility for ConfigLoader that does not support `config_patterns`
-        if not hasattr(config_loader, "config_patterns"):
-            return config_loader.get("databricks*", "databricks/**")
+    # Set the default pattern for `databricks` if not provided in `settings.py`
+    if "databricks" not in config_loader.config_patterns.keys():
+        config_loader.config_patterns.update(
+            {"databricks": ["databricks*", "databricks/**"]}
+        )
 
-        if not isinstance(config_loader, OmegaConfigLoader):
-            raise TypeError(
-                "Only OmegaConfigLoader is supported to load Databricks configuration."
-            )
+    if "databricks" not in config_loader.config_patterns.keys():
+        log.warning(
+            "No Databricks configuration found. "
+            "Please ensure that `databricks` is included in your config patterns."
+        )
 
-        # Set the default pattern for `databricks` if not provided in `settings.py`
-        if "databricks" not in config_loader.config_patterns.keys():
-            config_loader.config_patterns.update(
-                {"databricks": ["databricks*", "databricks/**"]}
-            )
-
-        if "databricks" not in config_loader.config_patterns.keys():
-            log.warning(
-                "No Databricks configuration found. "
-                "Please ensure that `databricks` is included in your config patterns."
-            )
-
-        try:
-            return config_loader["databricks"]
-        except MissingConfigException:
-            log.warning("No Databricks configuration found.")
-            return {}
+    try:
+        return config_loader["databricks"]
+    except MissingConfigException:
+        log.warning("No Databricks configuration found.")
+        return {}

--- a/src/kedro_databricks/commands/init.py
+++ b/src/kedro_databricks/commands/init.py
@@ -3,6 +3,8 @@ import json
 import re
 import shutil
 import tempfile
+from functools import reduce
+from operator import add
 from pathlib import Path
 
 import click
@@ -325,12 +327,18 @@ def _make_target_file_path(
 
 def _substitute_file_path(string: str) -> str:
     """Substitute the file path in the catalog"""
-    match = re.sub(
-        r"(.*:)\s*(?!https?://)(?:/[^/\s]+)*/?(data(?:/[^/\s]+)+)\s*$",
-        r"\g<1> ${_file_path}/\g<2>",
-        string,
-    )
-    return match
+    lines = string.splitlines(keepends=True)
+    new_lines = []
+    for line in lines:
+        new_lines.append(
+            re.sub(
+                r"(.*:)\s*(?!https?://)(?:/[^/\s]+)*/?(data(?:/[^/\s]+)+).*",
+                r"\g<1> ${_file_path}/\g<2>",
+                line,
+            )
+        )
+    sub = reduce(add, new_lines)
+    return sub
 
 
 def _save_target_catalog(

--- a/src/kedro_databricks/commands/init.py
+++ b/src/kedro_databricks/commands/init.py
@@ -326,8 +326,8 @@ def _make_target_file_path(
 def _substitute_file_path(string: str) -> str:
     """Substitute the file path in the catalog"""
     match = re.sub(
-        r"(.*:)(.*)(data/.*)",
-        r"\g<1> ${_file_path}/\g<3>",
+        r"(.*:)\s*(?!https?://)(?:/[^/\s]+)*/?(data(?:/[^/\s]+)+)\s*$",
+        r"\g<1> ${_file_path}/\g<2>",
         string,
     )
     return match

--- a/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 from kedro.framework.project import pipelines
 from kedro.framework.session.session import KedroSession
 from kedro.framework.startup import ProjectMetadata
-from kedro.io import MemoryDataset
+from kedro.io import DatasetNotFoundError, MemoryDataset
 from kedro.pipeline import Pipeline
 from kedro.pipeline.node import Node
 
@@ -76,9 +76,15 @@ class AbstractResourceGenerator(ABC):
                 raise ValueError("Expected pipeline of type Pipeline, got", type(p))
             p = cast(Pipeline, p)
             for d in p.datasets():
+                entry = None
                 try:
-                    entry = catalog[d]  # ty: ignore
-                except KeyError:
+                    if hasattr(catalog, "_get_dataset"):
+                        # Before version 1.0.0
+                        entry = catalog._get_dataset(d)  # type: ignore
+                    elif hasattr(catalog, "get"):
+                        # After version 1.0.0
+                        entry = catalog.get(d)  # type: ignore
+                except DatasetNotFoundError:
                     entry = None
                 if not entry or isinstance(entry, MemoryDataset):
                     memory_datasets.append(d)

--- a/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
@@ -69,14 +69,14 @@ class AbstractResourceGenerator(ABC):
         Returns:
             set[str]: A unique list of dataset names of type MemoryDataset
         """
-        catalog = self.context.catalog
+        catalog = self.context.catalog  # ty: ignore
         memory_datasets = []
         for p in self.pipelines.values():
             if not isinstance(p, Pipeline):  # pragma: no cover
                 raise ValueError("Expected pipeline of type Pipeline, got", type(p))
             p = cast(Pipeline, p)
             for d in p.datasets():
-                entry = catalog.get(d)
+                entry = catalog.get(d)  # ty: ignore
                 if not entry or isinstance(entry, MemoryDataset):
                     memory_datasets.append(d)
         return set(memory_datasets)

--- a/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
@@ -69,14 +69,17 @@ class AbstractResourceGenerator(ABC):
         Returns:
             set[str]: A unique list of dataset names of type MemoryDataset
         """
-        catalog = self.context.catalog  # ty: ignore
+        catalog = self.context.catalog
         memory_datasets = []
         for p in self.pipelines.values():
             if not isinstance(p, Pipeline):  # pragma: no cover
                 raise ValueError("Expected pipeline of type Pipeline, got", type(p))
             p = cast(Pipeline, p)
             for d in p.datasets():
-                entry = catalog.get(d)  # ty: ignore
+                try:
+                    entry = catalog[d]
+                except KeyError:
+                    entry = None
                 if not entry or isinstance(entry, MemoryDataset):
                     memory_datasets.append(d)
         return set(memory_datasets)

--- a/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
@@ -77,7 +77,7 @@ class AbstractResourceGenerator(ABC):
             p = cast(Pipeline, p)
             for d in p.datasets():
                 try:
-                    entry = catalog[d]
+                    entry = catalog[d]  # ty: ignore
                 except KeyError:
                     entry = None
                 if not entry or isinstance(entry, MemoryDataset):

--- a/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, MutableMapping
-from typing import Any
+from typing import Any, cast
 
 from kedro.framework.project import pipelines
+from kedro.framework.session.session import KedroSession
 from kedro.framework.startup import ProjectMetadata
+from kedro.io import MemoryDataset
 from kedro.pipeline import Pipeline
 from kedro.pipeline.node import Node
 
@@ -47,16 +49,42 @@ class AbstractResourceGenerator(ABC):
 
     def __init__(
         self,
+        session: KedroSession,
         metadata: ProjectMetadata,
-        env: str,
         conf_source: str = "conf",
         params: str | None = None,
     ) -> None:
         self.metadata = metadata
-        self.env = env
+        self.context = session.load_context()
         self.pipelines: MutableMapping = pipelines
         self.remote_conf_dir = f"/${{workspace.file_path}}/{conf_source}"
         self.params = params
+
+    def get_memory_datasets(self) -> set[str]:
+        """Get the names of inputs/outputs of type MemoryDataset
+
+        If a dataset has not been specified in the catalog, it will automatically
+        be added with type MemoryDataset.
+
+        Returns:
+            set[str]: A unique list of dataset names of type MemoryDataset
+        """
+        catalog = self.context.catalog
+        memory_datasets = []
+        for p in self.pipelines.values():
+            if not isinstance(p, Pipeline):  # pragma: no cover
+                raise ValueError("Expected pipeline of type Pipeline, got", type(p))
+            p = cast(Pipeline, p)
+            for d in p.datasets():
+                entry = catalog.get(d)
+                if not entry or isinstance(entry, MemoryDataset):
+                    memory_datasets.append(d)
+        return set(memory_datasets)
+
+    @abstractmethod
+    def can_handle_memory_datasets(self) -> bool:
+        """Determines if the generator can handle MemoryDataset"""
+        ...
 
     def generate_jobs(
         self, pipeline_name: str | None = None

--- a/src/kedro_databricks/utilities/resource_generator/node_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/node_resource_generator.py
@@ -18,6 +18,9 @@ from kedro_databricks.utilities.resource_generator.abstract_resource_generator i
 class NodeResourceGenerator(AbstractResourceGenerator):
     """Generate a job with one Databricks task per Kedro node."""
 
+    def can_handle_memory_datasets(self) -> bool:
+        return False
+
     def _create_job_dict(
         self, name: str, pipeline: Pipeline, pipeline_name: str
     ) -> dict[str, Any]:  # noqa: ARG002

--- a/src/kedro_databricks/utilities/resource_generator/pipeline_resource_generator.py
+++ b/src/kedro_databricks/utilities/resource_generator/pipeline_resource_generator.py
@@ -16,6 +16,9 @@ from kedro_databricks.utilities.resource_generator.abstract_resource_generator i
 class PipelineResourceGenerator(AbstractResourceGenerator):
     """Generate a job with a single task for the whole pipeline."""
 
+    def can_handle_memory_datasets(self) -> bool:
+        return True
+
     def _create_job_dict(
         self,
         name: str,

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -44,7 +44,7 @@ def test_run():
         metadata = bootstrap_project(project_path)
         # Arrange
         reset_project(metadata)
-        init_project(metadata, runner)
+        init_project(metadata, runner, with_catalog=False)
         bundle_project(metadata, runner)
         deploy_project(metadata, runner)
 

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -4,7 +4,6 @@ import shutil
 
 import yaml
 
-from kedro_databricks.commands.bundle import save_resources
 from kedro_databricks.constants import (
     DEFAULT_CONF_FOLDER,
     DEFAULT_CONFIG_GENERATOR,
@@ -13,10 +12,7 @@ from kedro_databricks.constants import (
 )
 from kedro_databricks.plugin import commands
 from kedro_databricks.utilities.common import get_arg_value
-from kedro_databricks.utilities.resource_generator import (
-    NodeResourceGenerator,
-)
-from tests.utils import reset_project, validate_bundle
+from tests.utils import reset_project, validate_bundle, write_catalog
 
 
 def task_validator(tasks):
@@ -33,6 +29,7 @@ def task_validator(tasks):
 def test_bundle(cli_runner, metadata):
     # Arrange
     reset_project(metadata)
+    write_catalog(metadata, DEFAULT_ENV)
     empty_overrides = {"resources": {"jobs": {}}}
     (metadata.project_path / "conf" / DEFAULT_ENV).mkdir(parents=True, exist_ok=True)
     with open(
@@ -77,6 +74,94 @@ def test_bundle(cli_runner, metadata):
     shutil.rmtree(metadata.project_path / "conf" / DEFAULT_ENV)
 
 
+def test_bundle_default_with_memory_datasets(cli_runner, metadata):
+    # Arrange
+    reset_project(metadata)
+    empty_overrides = {"resources": {"jobs": {}}}
+    (metadata.project_path / "conf" / DEFAULT_ENV).mkdir(parents=True, exist_ok=True)
+    with open(
+        metadata.project_path / "conf" / DEFAULT_ENV / "databricks.yml",
+        "w",
+    ) as f:
+        yaml.dump(empty_overrides, f)
+
+    with open(metadata.project_path / "conf" / "base" / "catalog.yml", "w") as f:
+        f.write("")
+    with open(metadata.project_path / "conf" / DEFAULT_ENV / "catalog.yml", "w") as f:
+        f.write("")
+
+    result = cli_runner.invoke(
+        commands,
+        [
+            "databricks",
+            "bundle",
+            "--env",
+            DEFAULT_ENV,
+            "--default-key",
+            DEFAULT_CONFIG_KEY,
+            "--resource-generator",
+            DEFAULT_CONFIG_GENERATOR,
+            "--conf-source",
+            DEFAULT_CONF_FOLDER,
+            "--overwrite",
+        ],
+        obj=metadata,
+    )
+
+    assert result.exit_code == 1, "bundle should fail"
+    assert (
+        "Resource Generator of type NodeResourceGenerator does not support MemoryDatasets"
+        in str(result.exception)
+    ), f"bundle should fail with MemoryDatasetError, not {result.exception}"
+
+
+def test_bundle_default_with_pipeline_generator(cli_runner, metadata):
+    # Arrange
+    reset_project(metadata)
+    empty_overrides = {"resources": {"jobs": {}}}
+    (metadata.project_path / "conf" / DEFAULT_ENV).mkdir(parents=True, exist_ok=True)
+    with open(
+        metadata.project_path / "conf" / DEFAULT_ENV / "databricks.yml",
+        "w",
+    ) as f:
+        yaml.dump(empty_overrides, f)
+
+    with open(metadata.project_path / "conf" / "base" / "catalog.yml", "w") as f:
+        f.write("")
+    with open(metadata.project_path / "conf" / DEFAULT_ENV / "catalog.yml", "w") as f:
+        f.write("")
+
+    result = cli_runner.invoke(
+        commands,
+        [
+            "databricks",
+            "bundle",
+            "--env",
+            DEFAULT_ENV,
+            "--default-key",
+            DEFAULT_CONFIG_KEY,
+            "--resource-generator",
+            "pipeline",
+            "--conf-source",
+            DEFAULT_CONF_FOLDER,
+            "--overwrite",
+        ],
+        obj=metadata,
+    )
+
+    assert result.exit_code == 0, "bundle should not fail with pipeline generator"
+    validate_bundle(
+        metadata=metadata,
+        env=DEFAULT_ENV,
+        required_files=[
+            f"target.{DEFAULT_ENV}.jobs.{metadata.package_name}.yml",
+            f"target.{DEFAULT_ENV}.jobs.{metadata.package_name}_namespaced_pipeline.yml",
+            f"target.{DEFAULT_ENV}.jobs.{metadata.package_name}_ds.yml",
+        ],
+        task_validator=task_validator,
+    )
+
+
 def test_bundle_no_overrides(cli_runner, metadata):
     # Act
     result = cli_runner.invoke(
@@ -117,26 +202,3 @@ def test_bundle_invalid_resource_generator(cli_runner, metadata):
 
     # Assert
     assert result.exit_code == 1, (result.exit_code, result.stdout, result.exception)
-
-
-def test_save_resources(metadata):
-    # Arrange
-    controller = NodeResourceGenerator(metadata, DEFAULT_ENV)
-    jobs = controller.generate_jobs()
-    resources = {"resources": {"jobs": jobs}}
-
-    # Act
-    save_resources(
-        metadata=metadata,
-        env=DEFAULT_ENV,
-        resources=resources,
-        overwrite=True,
-    )
-
-    # Assert
-    resource_dir = metadata.project_path / "resources"
-    assert resource_dir.exists(), "Failed to create resources directory"
-    assert resource_dir.is_dir(), "resouces is not a directory"
-    for job in jobs:
-        job_file = resource_dir / f"target.{DEFAULT_ENV}.jobs.{job}.yml"
-        assert job_file.exists(), f"Failed to save job resource: {job_file}"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -135,3 +135,211 @@ def test_prepare_template(metadata):
     except Exception as e:
         raise ValueError(f"Failed to load template params: {e} - {params}")
     shutil.rmtree(assets_dir)
+
+
+def test_substitute_catalog():
+    catalog = """
+_file_path: /Volumes/workspace/default/jenspederm/develop_eggs
+# Here you can define all your data sets by using simple YAML syntax.
+#
+# Documentation for this file format can be found in "The Data Catalog"
+# Link: https://docs.kedro.org/en/stable/data/data_catalog.html
+#
+# We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
+#
+# An example data set definition can look as follows:
+#
+#bikes:
+#  type: pandas.CSVDataset
+#  filepath: "data/01_raw/bikes.csv"
+#
+#weather:
+#  type: spark.SparkDatasetV2
+#  filepath: s3a://your_bucket/data/01_raw/weather*
+#  file_format: csv
+#  credentials: dev_s3
+#  load_args:
+#    header: True
+#    inferSchema: True
+#  save_args:
+#    sep: '|'
+#    header: True
+#
+#scooters:
+#  type: pandas.SQLTableDataset
+#  credentials: scooters_credentials
+#  table_name: scooters
+#  load_args:
+#    index_col: ['name']
+#    columns: ['name', 'gear']
+#  save_args:
+#    if_exists: 'replace'
+#    # if_exists: 'fail'
+#    # if_exists: 'append'
+#
+# The Data Catalog supports being able to reference the same file using two different Dataset implementations
+# (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
+# https://docs.kedro.org/en/stable/data/data_catalog.html
+#
+# This is a data set used by the iris classification example pipeline provided with this starter
+# template. Please feel free to remove it once you remove the example pipeline.
+
+example_iris_data:
+  type: spark.SparkDatasetV2
+  filepath: /dbfs/FileStore/develop_eggs/data/01_raw/iris.csv
+  file_format: csv
+  load_args:
+    header: True
+    inferSchema: True
+  save_args:
+    header: True
+
+# We need to set mode to 'overwrite' in save_args so when saving the dataset it is replaced each time it is run
+# for all SparkDatasetV2s.
+X_train@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/X_train.parquet
+  save_args:
+    mode: overwrite
+
+X_train@pandas:
+  type: pandas.ParquetDataset
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/X_train.parquet
+
+X_test@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/X_test.parquet
+  save_args:
+    mode: overwrite
+
+X_test@pandas:
+  type: pandas.ParquetDataset
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/X_test.parquet
+
+y_train@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/y_train.parquet
+  save_args:
+    mode: overwrite
+
+y_train@pandas:
+  type: pandas.ParquetDataset
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/y_train.parquet
+
+y_test@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/y_test.parquet
+  save_args:
+    mode: overwrite
+
+y_test@pandas:
+  type: pandas.ParquetDataset
+  filepath: /dbfs/FileStore/develop_eggs/data/02_intermediate/y_test.parquet
+
+y_pred:
+  type: pandas.ParquetDataset
+  filepath: ${_file_path}/data/03_primary/y_pred.parquet
+"""
+    expected = """
+_file_path: /Volumes/workspace/default/jenspederm/develop_eggs
+# Here you can define all your data sets by using simple YAML syntax.
+#
+# Documentation for this file format can be found in "The Data Catalog"
+# Link: https://docs.kedro.org/en/stable/data/data_catalog.html
+#
+# We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
+#
+# An example data set definition can look as follows:
+#
+#bikes:
+#  type: pandas.CSVDataset
+#  filepath: "data/01_raw/bikes.csv"
+#
+#weather:
+#  type: spark.SparkDatasetV2
+#  filepath: s3a://your_bucket/data/01_raw/weather*
+#  file_format: csv
+#  credentials: dev_s3
+#  load_args:
+#    header: True
+#    inferSchema: True
+#  save_args:
+#    sep: '|'
+#    header: True
+#
+#scooters:
+#  type: pandas.SQLTableDataset
+#  credentials: scooters_credentials
+#  table_name: scooters
+#  load_args:
+#    index_col: ['name']
+#    columns: ['name', 'gear']
+#  save_args:
+#    if_exists: 'replace'
+#    # if_exists: 'fail'
+#    # if_exists: 'append'
+#
+# The Data Catalog supports being able to reference the same file using two different Dataset implementations
+# (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
+# https://docs.kedro.org/en/stable/data/data_catalog.html
+#
+# This is a data set used by the iris classification example pipeline provided with this starter
+# template. Please feel free to remove it once you remove the example pipeline.
+
+example_iris_data:
+  type: spark.SparkDatasetV2
+  filepath: ${_file_path}/data/01_raw/iris.csv
+  file_format: csv
+  load_args:
+    header: True
+    inferSchema: True
+  save_args:
+    header: True
+
+# We need to set mode to 'overwrite' in save_args so when saving the dataset it is replaced each time it is run
+# for all SparkDatasetV2s.
+X_train@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: ${_file_path}/data/02_intermediate/X_train.parquet
+  save_args:
+    mode: overwrite
+
+X_train@pandas:
+  type: pandas.ParquetDataset
+  filepath: ${_file_path}/data/02_intermediate/X_train.parquet
+
+X_test@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: ${_file_path}/data/02_intermediate/X_test.parquet
+  save_args:
+    mode: overwrite
+
+X_test@pandas:
+  type: pandas.ParquetDataset
+  filepath: ${_file_path}/data/02_intermediate/X_test.parquet
+
+y_train@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: ${_file_path}/data/02_intermediate/y_train.parquet
+  save_args:
+    mode: overwrite
+
+y_train@pandas:
+  type: pandas.ParquetDataset
+  filepath: ${_file_path}/data/02_intermediate/y_train.parquet
+
+y_test@pyspark:
+  type: spark.SparkDatasetV2
+  filepath: ${_file_path}/data/02_intermediate/y_test.parquet
+  save_args:
+    mode: overwrite
+
+y_test@pandas:
+  type: pandas.ParquetDataset
+  filepath: ${_file_path}/data/02_intermediate/y_test.parquet
+
+y_pred:
+  type: pandas.ParquetDataset
+  filepath: ${_file_path}/data/03_primary/y_pred.parquet
+"""
+    assert _substitute_file_path(catalog) == expected

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -70,8 +70,24 @@ def test_write_databricks_run_script(metadata):
             "file_path: ${_file_path}/data/012_raw/file.csv",
         ),
         (
+            "file_path:data/012_raw/file.csv",
+            "file_path: ${_file_path}/data/012_raw/file.csv",
+        ),
+        (
             "file_path: /custom/path/data/01_raw/file.csv",
             "file_path: ${_file_path}/data/01_raw/file.csv",
+        ),
+        (
+            "file_path: /custom/path/data/01_raw/file.json",
+            "file_path: ${_file_path}/data/01_raw/file.json",
+        ),
+        (
+            "file_path: https://website.com/data/file.csv",
+            "file_path: https://website.com/data/file.csv",
+        ),
+        (
+            "file_path: https://website.com/data/file.json",
+            "file_path: https://website.com/data/file.json",
         ),
         ("data/01_raw/file.csv", "data/01_raw/file.csv"),
     ],

--- a/tests/unit/test_utilities_resource_generators.py
+++ b/tests/unit/test_utilities_resource_generators.py
@@ -1,6 +1,8 @@
 import pytest
+from kedro.framework.session import KedroSession
 from kedro.pipeline import Pipeline
 
+from kedro_databricks.constants import DEFAULT_ENV
 from kedro_databricks.utilities.common import require_databricks_run_script
 from kedro_databricks.utilities.resource_generator import (
     NodeResourceGenerator,
@@ -10,194 +12,234 @@ from tests.utils import JOB, _generate_task, identity, long_identity, node, pipe
 
 
 def test_create_job(metadata):
-    g = NodeResourceGenerator(metadata, "fake_env")
-    assert g._create_job("job1", pipeline, "__default__") == JOB
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(session=session, metadata=metadata)
+        assert g._create_job("job1", pipeline, "__default__") == JOB
 
 
 def test_create_job_pipeline(metadata):
-    g = PipelineResourceGenerator(metadata, "fake_env")
-    assert g._create_job("job1", pipeline, "__default__") is not None
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = PipelineResourceGenerator(session=session, metadata=metadata)
+        assert g._create_job("job1", pipeline, "__default__") is not None
 
 
 def test_create_job_pipeline_fails(metadata):
-    g = PipelineResourceGenerator(metadata, "fake_env")
-    with pytest.raises(
-        ValueError,
-        match="Pipeline name must be provided to create a job dict when --pipeline is used.",
-    ):
-        g._create_job("job1", pipeline, None)  # type: ignore
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = PipelineResourceGenerator(session=session, metadata=metadata)
+        with pytest.raises(
+            ValueError,
+            match="Pipeline name must be provided to create a job dict when --pipeline is used.",
+        ):
+            g._create_job("job1", pipeline, None)  # type: ignore
 
 
 def test_create_task(metadata):
-    g = NodeResourceGenerator(metadata, "fake_env")
-    expected_task = _generate_task("task", ["a", "b"])
-    node_a = node(identity, ["input"], ["output"], name="a")
-    node_b = node(identity, ["input"], ["output"], name="b")
-    assert (
-        g._create_task(
-            node(
-                long_identity,
-                ["input", "input1", "input2"],
-                ["output", "output1"],
-                name="task",
-            ),
-            [
-                node_b,
-                node_a,
-            ],
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(session=session, metadata=metadata)
+        expected_task = _generate_task("task", ["a", "b"])
+        node_a = node(identity, ["input"], ["output"], name="a")
+        node_b = node(identity, ["input"], ["output"], name="b")
+        assert (
+            g._create_task(
+                node(
+                    long_identity,
+                    ["input", "input1", "input2"],
+                    ["output", "output1"],
+                    name="task",
+                ),
+                [
+                    node_b,
+                    node_a,
+                ],
+            )
+            == expected_task
         )
-        == expected_task
-    )
 
 
 def test_create_pipeline_task(metadata):
-    g = PipelineResourceGenerator(metadata, "fake_env")
-    pipeline_name = "pipeline_task"
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = PipelineResourceGenerator(session=session, metadata=metadata)
+        pipeline_name = "pipeline_task"
 
-    if require_databricks_run_script():
-        entry_point = "databricks_run"
-        extra_params = ["--package-name", "fake_project"]
-    else:
-        entry_point = "fake-project"
-        extra_params = []
+        if require_databricks_run_script():
+            entry_point = "databricks_run"
+            extra_params = ["--package-name", "fake_project"]
+        else:
+            entry_point = "fake-project"
+            extra_params = []
 
-    assert g._create_pipeline_task(pipeline_name) == {
-        "task_key": pipeline_name,
-        "depends_on": [],
-        "python_wheel_task": {
-            "entry_point": entry_point,
-            "package_name": "fake_project",
-            "parameters": [
-                "--pipeline",
-                pipeline_name,
-                "--conf-source",
-                "/${workspace.file_path}/conf",
-                "--env",
-                "${var.environment}",
-                *extra_params,
-            ],
-        },
-    }
+        assert g._create_pipeline_task(pipeline_name) == {
+            "task_key": pipeline_name,
+            "depends_on": [],
+            "python_wheel_task": {
+                "entry_point": entry_point,
+                "package_name": "fake_project",
+                "parameters": [
+                    "--pipeline",
+                    pipeline_name,
+                    "--conf-source",
+                    "/${workspace.file_path}/conf",
+                    "--env",
+                    "${var.environment}",
+                    *extra_params,
+                ],
+            },
+        }
 
 
 def test_create_task_with_runtime_params(metadata):
-    controller = NodeResourceGenerator(
-        metadata, "fake_env", params="key1=value1,key2=value2"
-    )
-    expected_task = _generate_task(
-        "task", ["a", "b"], runtime_params="key1=value1,key2=value2"
-    )
-    node_a = node(identity, ["input"], ["output"], name="a")
-    node_b = node(identity, ["input"], ["output"], name="b")
-    assert (
-        controller._create_task(
-            node(
-                long_identity,
-                ["input", "input1", "input2"],
-                ["output", "output1"],
-                name="task",
-            ),
-            [
-                node_b,
-                node_a,
-            ],
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(
+            session=session, metadata=metadata, params="key1=value1,key2=value2"
         )
-        == expected_task
-    )
+        expected_task = _generate_task(
+            "task", ["a", "b"], runtime_params="key1=value1,key2=value2"
+        )
+        node_a = node(identity, ["input"], ["output"], name="a")
+        node_b = node(identity, ["input"], ["output"], name="b")
+        assert (
+            g._create_task(
+                node(
+                    long_identity,
+                    ["input", "input1", "input2"],
+                    ["output", "output1"],
+                    name="task",
+                ),
+                [
+                    node_b,
+                    node_a,
+                ],
+            )
+            == expected_task
+        )
 
 
 def test_generate_resources(metadata):
-    controller = NodeResourceGenerator(metadata, "fake_env")
-    controller.pipelines = {"__default__": Pipeline([])}
-    assert controller.generate_jobs(pipeline_name=None) == {}
-    controller.pipelines = {
-        "__default__": Pipeline([node(identity, ["input"], ["output"], name="node")])
-    }
-    assert controller.generate_jobs(pipeline_name=None) == {
-        "fake_project": {
-            "name": "fake_project",
-            "tasks": [
-                _generate_task("node"),
-            ],
-        },
-    }
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(session=session, metadata=metadata)
+        g.pipelines = {"__default__": Pipeline([])}
+        assert g.generate_jobs(pipeline_name=None) == {}
+        g.pipelines = {
+            "__default__": Pipeline(
+                [node(identity, ["input"], ["output"], name="node")]
+            )
+        }
+        assert g.generate_jobs(pipeline_name=None) == {
+            "fake_project": {
+                "name": "fake_project",
+                "tasks": [
+                    _generate_task("node"),
+                ],
+            },
+        }
 
 
 def test_generate_resources_non_existent_pipeline(metadata):
-    controller = NodeResourceGenerator(metadata, "fake_env")
-    controller.pipelines = {"__default__": Pipeline([])}
-    assert controller.generate_jobs(pipeline_name=None) == {}
-    controller.pipelines = {
-        "__default__": Pipeline([node(identity, ["input"], ["output"], name="node")])
-    }
-    with pytest.raises(
-        KeyError,
-        match="Pipeline 'non_existent_pipeline' not found. Available pipelines:",
-    ):
-        controller.generate_jobs(pipeline_name="non_existent_pipeline")
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(session=session, metadata=metadata)
+        g.pipelines = {"__default__": Pipeline([])}
+        assert g.generate_jobs(pipeline_name=None) == {}
+        g.pipelines = {
+            "__default__": Pipeline(
+                [node(identity, ["input"], ["output"], name="node")]
+            )
+        }
+        with pytest.raises(
+            KeyError,
+            match="Pipeline 'non_existent_pipeline' not found. Available pipelines:",
+        ):
+            g.generate_jobs(pipeline_name="non_existent_pipeline")
 
 
 def test_generate_resources_another_conf(metadata):
-    controller = NodeResourceGenerator(metadata, "fake_env", "sub_conf")
-    controller.pipelines = {
-        "__default__": Pipeline([node(identity, ["input"], ["output"], name="node")])
-    }
-
-    assert controller.generate_jobs(pipeline_name=None) == {
-        "fake_project": {
-            "name": "fake_project",
-            "tasks": [
-                _generate_task("node", conf="sub_conf"),
-            ],
-        },
-    }
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(
+            session=session, metadata=metadata, conf_source="sub_conf"
+        )
+        g.pipelines = {
+            "__default__": Pipeline(
+                [node(identity, ["input"], ["output"], name="node")]
+            )
+        }
+        assert g.generate_jobs(pipeline_name=None) == {
+            "fake_project": {
+                "name": "fake_project",
+                "tasks": [
+                    _generate_task("node", conf="sub_conf"),
+                ],
+            },
+        }
 
 
 def test_generate_resources_in_a_sorted_manner(metadata):
-    controller = NodeResourceGenerator(metadata, "fake_env")
-    controller.pipelines = {
-        "__default__": Pipeline(
-            [
-                node(identity, ["input"], ["b_output"], name="b_node"),
-                node(identity, ["input"], ["a_output"], name="a_node"),
-            ]
-        )
-    }
-    assert controller.generate_jobs(pipeline_name=None) == {
-        "fake_project": {
-            "name": "fake_project",
-            "tasks": [
-                _generate_task("a_node"),
-                _generate_task("b_node"),
-            ],
-        },
-    }
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(session=session, metadata=metadata)
+        g.pipelines = {
+            "__default__": Pipeline(
+                [
+                    node(identity, ["input"], ["b_output"], name="b_node"),
+                    node(identity, ["input"], ["a_output"], name="a_node"),
+                ]
+            )
+        }
+        assert g.generate_jobs(pipeline_name=None) == {
+            "fake_project": {
+                "name": "fake_project",
+                "tasks": [
+                    _generate_task("a_node"),
+                    _generate_task("b_node"),
+                ],
+            },
+        }
 
 
 def test_generate_resources_for_a_single_pipeline(metadata):
-    controller = NodeResourceGenerator(metadata, "fake_env")
-    controller.pipelines = {
-        "__default__": Pipeline(
-            [
-                node(identity, ["input"], ["a_output"], name="a_node"),
-            ]
-        ),
-        "a_pipeline": Pipeline(
-            [
-                node(identity, ["input"], ["a_output"], name="a_node"),
-            ]
-        ),
-        "b_pipeline": Pipeline(
-            [
-                node(identity, ["input"], ["b_output"], name="b_node"),
-            ]
-        ),
-    }
-    assert controller.generate_jobs(pipeline_name="b_pipeline") == {
-        "fake_project_b_pipeline": {
-            "name": "fake_project_b_pipeline",
-            "tasks": [
-                _generate_task("b_node"),
-            ],
-        },
-    }
+    with KedroSession.create(
+        project_path=metadata.project_path, env=DEFAULT_ENV
+    ) as session:
+        g = NodeResourceGenerator(session=session, metadata=metadata)
+        g.pipelines = {
+            "__default__": Pipeline(
+                [
+                    node(identity, ["input"], ["a_output"], name="a_node"),
+                ]
+            ),
+            "a_pipeline": Pipeline(
+                [
+                    node(identity, ["input"], ["a_output"], name="a_node"),
+                ]
+            ),
+            "b_pipeline": Pipeline(
+                [
+                    node(identity, ["input"], ["b_output"], name="b_node"),
+                ]
+            ),
+        }
+        assert g.generate_jobs(pipeline_name="b_pipeline") == {
+            "fake_project_b_pipeline": {
+                "name": "fake_project_b_pipeline",
+                "tasks": [
+                    _generate_task("b_node"),
+                ],
+            },
+        }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,13 +18,18 @@ from kedro_databricks.plugin import commands
 from kedro_databricks.utilities.common import require_databricks_run_script
 
 
-def init_project(metadata: ProjectMetadata, cli_runner: CliRunner):
+def init_project(
+    metadata: ProjectMetadata, cli_runner: CliRunner, with_catalog: bool = True
+):
     init_cmd = ["databricks", "init"]
     result = cli_runner.invoke(commands, init_cmd, obj=metadata)
     assert result.exit_code == 0, (result.exit_code, result.stdout, result.exception)
     assert metadata.project_path.exists(), "Project path not created"
     assert metadata.project_path.is_dir(), "Project path is not a directory"
     assert metadata.project_path / "databricks.yml", "Databricks config not created"
+
+    if with_catalog:
+        write_catalog(metadata, DEFAULT_ENV)
 
     databricks_config = _read_databricks_config(metadata.project_path)
     targets = _get_targets(databricks_config)
@@ -208,6 +213,28 @@ def validate_bundle(
             tasks = job.get("tasks")
             assert tasks is not None, f"Tasks not found in job {file}"
             task_validator(tasks)
+
+
+def write_catalog(metadata: ProjectMetadata, env: str):
+    datasets = [
+        "output_6_output_6_1",
+        "output2",
+        "output3",
+        "output",
+        "output4",
+        "output_5_output_5_1",
+        "intermediate",
+        "output_7_output_7_1",
+        "input",
+    ]
+
+    with open(metadata.project_path / "conf" / env / "catalog.yml", "w") as f:
+        for d in datasets:
+            f.write(f"""
+{d}:
+    type: pandas.CSVDataset
+    filepath: data/01_raw/{d}.csv
+""")
 
 
 def identity(arg):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -216,6 +216,7 @@ def validate_bundle(
 
 
 def write_catalog(metadata: ProjectMetadata, env: str):
+    (metadata.project_path / "conf" / env).mkdir(parents=True, exist_ok=True)
     datasets = [
         "output_6_output_6_1",
         "output2",
@@ -228,7 +229,7 @@ def write_catalog(metadata: ProjectMetadata, env: str):
         "input",
     ]
 
-    with open(metadata.project_path / "conf" / env / "catalog.yml", "w") as f:
+    with open(metadata.project_path / "conf" / env / "catalog.yml", "w+") as f:
         for d in datasets:
             f.write(f"""
 {d}:

--- a/uv.lock
+++ b/uv.lock
@@ -428,15 +428,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-strenum"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
-]
-
-[[package]]
 name = "backrefs"
 version = "6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1061,7 +1052,7 @@ resolution-markers = [
 dependencies = [
     { name = "numpy", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "pyarrow", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/75/7cbd2af9f3bed29c74df4c6512243b94e0dc17ca03bf82a33e45ee75501b/db_dtypes-1.4.4.tar.gz", hash = "sha256:26f53db5df1acd746b88c5647913a1b20f731c0af1b11abcb6bec5365f31098a", size = 34471, upload-time = "2025-11-11T17:21:59.221Z" }
@@ -1082,7 +1073,7 @@ resolution-markers = [
 dependencies = [
     { name = "numpy", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "pandas", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
     { name = "pyarrow", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/8b/8a7417de5f21f1f2ca7b7365e1367320d84df457bedebafae1f4f72813a0/db_dtypes-1.5.1.tar.gz", hash = "sha256:901099b807c9312bc61a5bddbfb07512884e6c6d5a9edacf24d50bcf303aa5f7", size = 35751, upload-time = "2026-03-30T22:50:49.561Z" }
@@ -1147,6 +1138,19 @@ wheels = [
 ]
 
 [[package]]
+name = "delta-spark"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "pyspark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c9/a4d34fee1dafcad33d4e810ff2ce14a9f6e8e7af9797a9de79ebc3334987/delta_spark-3.3.2.tar.gz", hash = "sha256:f3e89ec4a15a541988f9d6496016a67cf619475e8eeca71da5e073f6ba0da845", size = 23066, upload-time = "2025-05-29T22:25:49.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/b7/f484bca84628f9f7a9a16ecfd8b010edbda9fa3f5e3918e967ddd69bf6af/delta_spark-3.3.2-py3-none-any.whl", hash = "sha256:0a34c720b4368f1655e2348e380b5b3baaca0f2b3d519a3198208f00f65e4062", size = 22024, upload-time = "2025-05-29T22:25:48.008Z" },
+]
+
+[[package]]
 name = "deltalake"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1184,6 +1188,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
 name = "dynaconf"
@@ -1712,6 +1722,17 @@ wheels = [
 ]
 
 [[package]]
+name = "hdfs"
+version = "2.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docopt" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/c7/1be559eb10cb7cac0d26373f18656c8037553619ddd4098e50b04ea8b4ab/hdfs-2.7.3.tar.gz", hash = "sha256:752a21e43f82197dce43697c73f454ba490838108c73a57a9247efb66d1c0479", size = 43540, upload-time = "2023-10-13T00:06:06.144Z" }
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1759,14 +1780,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
 ]
 
 [[package]]
@@ -2220,7 +2241,7 @@ test = [
     { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "jupyterlab" },
-    { name = "kedro-datasets", extra = ["pandas", "pandas-parquetdataset", "spark"] },
+    { name = "kedro-datasets", extra = ["pandas", "pandas-parquetdataset", "spark", "spark-sparkdataset"] },
     { name = "notebook" },
     { name = "numpy" },
 ]
@@ -2261,26 +2282,23 @@ test = [
 
 [[package]]
 name = "kedro-datasets"
-version = "9.3.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-strenum", marker = "python_full_version < '3.11'" },
     { name = "kedro" },
     { name = "lazy-loader" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/23/d252c0c4b84f320b3c052bd8b6040b7dc1404f7f99869eb996d8fee76d14/kedro_datasets-9.3.0.tar.gz", hash = "sha256:afb07b567736e3bd4008cd44ca8fa6a052e6f51686cb0dc9e592f5c7ac9907f3", size = 202987, upload-time = "2026-04-02T15:55:40.727Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/36/187729057281fa1c92963cc649aa66477fb24e487c59ada2df68d1b47689/kedro_datasets-7.0.0.tar.gz", hash = "sha256:637c5ddca753e54e2ad30916e85396f433513bd6d589460ca74bec3574a92256", size = 127311, upload-time = "2025-04-25T14:57:34.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/00/10948ec45d55303670af611575370465153eec2d7a5d95d344673680b03c/kedro_datasets-9.3.0-py3-none-any.whl", hash = "sha256:6638feb4c6932c513d18f1a6537975f73832687ac148e21e0a0390a99176d270", size = 322222, upload-time = "2026-04-02T15:55:38.426Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3e/ea9fdc4c944397ccbc45cf3f4af2c84e8d94c49a3c39fa3acc114a97e57e/kedro_datasets-7.0.0-py3-none-any.whl", hash = "sha256:8d8315bbf26e6f33e4382a9923bb2b95303f447e4f46a15bbe1a0527653ae7e6", size = 220612, upload-time = "2025-04-25T14:57:32.635Z" },
 ]
 
 [package.optional-dependencies]
 pandas = [
     { name = "deltalake" },
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "lxml" },
     { name = "openpyxl" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas" },
     { name = "pandas-gbq" },
     { name = "pyarrow" },
     { name = "pyodbc" },
@@ -2289,11 +2307,17 @@ pandas = [
     { name = "tables", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 pandas-parquetdataset = [
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas" },
     { name = "pyarrow" },
 ]
 spark = [
+    { name = "delta-spark" },
+    { name = "hdfs" },
+    { name = "pyspark" },
+    { name = "s3fs" },
+]
+spark-sparkdataset = [
+    { name = "hdfs" },
     { name = "pyspark" },
     { name = "s3fs" },
 ]
@@ -2339,15 +2363,6 @@ wheels = [
 name = "lxml"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/84/14/c2070b5e37c650198de8328467dd3d1681e80986f81ba0fea04fc4ec9883/lxml-4.9.4.tar.gz", hash = "sha256:b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e", size = 3576664, upload-time = "2023-12-19T19:37:24.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/e4/e37f7f61ceaf0b29e7c5bf78fb1927818a52c986546459d33ccd742f2b8e/lxml-4.9.4-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:056a17eaaf3da87a05523472ae84246f87ac2f29a53306466c22e60282e54ff8", size = 4772989, upload-time = "2023-12-19T18:43:03.483Z" },
@@ -2379,96 +2394,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/54/e7cc9b0019209fc553d5cb4cb460df25513754666665d5cd0f0ec19685ed/lxml-4.9.4-pp310-pypy310_pp73-macosx_11_0_x86_64.whl", hash = "sha256:f6c35b2f87c004270fa2e703b872fcc984d714d430b305145c39d53074e1ffe0", size = 4032797, upload-time = "2023-12-19T19:29:52.652Z" },
     { url = "https://files.pythonhosted.org/packages/60/8a/fc26540cc544a989277bdedeb098604ea7da998ebfd7bd0e94a3a936a817/lxml-4.9.4-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:606d445feeb0856c2b424405236a01c71af7c97e5fe42fbc778634faef2b47e4", size = 6337726, upload-time = "2023-12-19T19:30:32.228Z" },
     { url = "https://files.pythonhosted.org/packages/32/6e/8da1c75c1e3f4a92255ed48cc5ab9163c0d942dbfcea500409c670db173e/lxml-4.9.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a1bdcbebd4e13446a14de4dd1825f1e778e099f17f79718b4aeaf2403624b0f7", size = 3395151, upload-time = "2023-12-19T19:30:50.088Z" },
-]
-
-[[package]]
-name = "lxml"
-version = "5.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/3d/14e82fc7c8fb1b7761f7e748fd47e2ec8276d137b6acfe5a4bb73853e08f/lxml-5.4.0.tar.gz", hash = "sha256:d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd", size = 3679479, upload-time = "2025-04-23T01:50:29.322Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/1f/a3b6b74a451ceb84b471caa75c934d2430a4d84395d38ef201d539f38cd1/lxml-5.4.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e7bc6df34d42322c5289e37e9971d6ed114e3776b45fa879f734bded9d1fea9c", size = 8076838, upload-time = "2025-04-23T01:44:29.325Z" },
-    { url = "https://files.pythonhosted.org/packages/36/af/a567a55b3e47135b4d1f05a1118c24529104c003f95851374b3748139dc1/lxml-5.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6854f8bd8a1536f8a1d9a3655e6354faa6406621cf857dc27b681b69860645c7", size = 4381827, upload-time = "2025-04-23T01:44:33.345Z" },
-    { url = "https://files.pythonhosted.org/packages/50/ba/4ee47d24c675932b3eb5b6de77d0f623c2db6dc466e7a1f199792c5e3e3a/lxml-5.4.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:696ea9e87442467819ac22394ca36cb3d01848dad1be6fac3fb612d3bd5a12cf", size = 5204098, upload-time = "2025-04-23T01:44:35.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/0f/b4db6dfebfefe3abafe360f42a3d471881687fd449a0b86b70f1f2683438/lxml-5.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ef80aeac414f33c24b3815ecd560cee272786c3adfa5f31316d8b349bfade28", size = 4930261, upload-time = "2025-04-23T01:44:38.271Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/1f/0bb1bae1ce056910f8db81c6aba80fec0e46c98d77c0f59298c70cd362a3/lxml-5.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b9c2754cef6963f3408ab381ea55f47dabc6f78f4b8ebb0f0b25cf1ac1f7609", size = 5529621, upload-time = "2025-04-23T01:44:40.921Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f5/e7b66a533fc4a1e7fa63dd22a1ab2ec4d10319b909211181e1ab3e539295/lxml-5.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a62cc23d754bb449d63ff35334acc9f5c02e6dae830d78dab4dd12b78a524f4", size = 4983231, upload-time = "2025-04-23T01:44:43.871Z" },
-    { url = "https://files.pythonhosted.org/packages/11/39/a38244b669c2d95a6a101a84d3c85ba921fea827e9e5483e93168bf1ccb2/lxml-5.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f82125bc7203c5ae8633a7d5d20bcfdff0ba33e436e4ab0abc026a53a8960b7", size = 5084279, upload-time = "2025-04-23T01:44:46.632Z" },
-    { url = "https://files.pythonhosted.org/packages/db/64/48cac242347a09a07740d6cee7b7fd4663d5c1abd65f2e3c60420e231b27/lxml-5.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b67319b4aef1a6c56576ff544b67a2a6fbd7eaee485b241cabf53115e8908b8f", size = 4927405, upload-time = "2025-04-23T01:44:49.843Z" },
-    { url = "https://files.pythonhosted.org/packages/98/89/97442835fbb01d80b72374f9594fe44f01817d203fa056e9906128a5d896/lxml-5.4.0-cp310-cp310-manylinux_2_28_ppc64le.whl", hash = "sha256:a8ef956fce64c8551221f395ba21d0724fed6b9b6242ca4f2f7beb4ce2f41997", size = 5550169, upload-time = "2025-04-23T01:44:52.791Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/97/164ca398ee654eb21f29c6b582685c6c6b9d62d5213abc9b8380278e9c0a/lxml-5.4.0-cp310-cp310-manylinux_2_28_s390x.whl", hash = "sha256:0a01ce7d8479dce84fc03324e3b0c9c90b1ece9a9bb6a1b6c9025e7e4520e78c", size = 5062691, upload-time = "2025-04-23T01:44:56.108Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/bc/712b96823d7feb53482d2e4f59c090fb18ec7b0d0b476f353b3085893cda/lxml-5.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:91505d3ddebf268bb1588eb0f63821f738d20e1e7f05d3c647a5ca900288760b", size = 5133503, upload-time = "2025-04-23T01:44:59.222Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/55/a62a39e8f9da2a8b6002603475e3c57c870cd9c95fd4b94d4d9ac9036055/lxml-5.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a3bcdde35d82ff385f4ede021df801b5c4a5bcdfb61ea87caabcebfc4945dc1b", size = 4999346, upload-time = "2025-04-23T01:45:02.088Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/a393728ae001b92bb1a9e095e570bf71ec7f7fbae7688a4792222e56e5b9/lxml-5.4.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:aea7c06667b987787c7d1f5e1dfcd70419b711cdb47d6b4bb4ad4b76777a0563", size = 5627139, upload-time = "2025-04-23T01:45:04.582Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/5f/9dcaaad037c3e642a7ea64b479aa082968de46dd67a8293c541742b6c9db/lxml-5.4.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a7fb111eef4d05909b82152721a59c1b14d0f365e2be4c742a473c5d7372f4f5", size = 5465609, upload-time = "2025-04-23T01:45:07.649Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0a/ebcae89edf27e61c45023005171d0ba95cb414ee41c045ae4caf1b8487fd/lxml-5.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:43d549b876ce64aa18b2328faff70f5877f8c6dede415f80a2f799d31644d776", size = 5192285, upload-time = "2025-04-23T01:45:10.456Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ad/cc8140ca99add7d85c92db8b2354638ed6d5cc0e917b21d36039cb15a238/lxml-5.4.0-cp310-cp310-win32.whl", hash = "sha256:75133890e40d229d6c5837b0312abbe5bac1c342452cf0e12523477cd3aa21e7", size = 3477507, upload-time = "2025-04-23T01:45:12.474Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/39/597ce090da1097d2aabd2f9ef42187a6c9c8546d67c419ce61b88b336c85/lxml-5.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:de5b4e1088523e2b6f730d0509a9a813355b7f5659d70eb4f319c76beea2e250", size = 3805104, upload-time = "2025-04-23T01:45:15.104Z" },
-    { url = "https://files.pythonhosted.org/packages/81/2d/67693cc8a605a12e5975380d7ff83020dcc759351b5a066e1cced04f797b/lxml-5.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:98a3912194c079ef37e716ed228ae0dcb960992100461b704aea4e93af6b0bb9", size = 8083240, upload-time = "2025-04-23T01:45:18.566Z" },
-    { url = "https://files.pythonhosted.org/packages/73/53/b5a05ab300a808b72e848efd152fe9c022c0181b0a70b8bca1199f1bed26/lxml-5.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0ea0252b51d296a75f6118ed0d8696888e7403408ad42345d7dfd0d1e93309a7", size = 4387685, upload-time = "2025-04-23T01:45:21.387Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cb/1a3879c5f512bdcd32995c301886fe082b2edd83c87d41b6d42d89b4ea4d/lxml-5.4.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b92b69441d1bd39f4940f9eadfa417a25862242ca2c396b406f9272ef09cdcaa", size = 4991164, upload-time = "2025-04-23T01:45:23.849Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/94/bbc66e42559f9d04857071e3b3d0c9abd88579367fd2588a4042f641f57e/lxml-5.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20e16c08254b9b6466526bc1828d9370ee6c0d60a4b64836bc3ac2917d1e16df", size = 4746206, upload-time = "2025-04-23T01:45:26.361Z" },
-    { url = "https://files.pythonhosted.org/packages/66/95/34b0679bee435da2d7cae895731700e519a8dfcab499c21662ebe671603e/lxml-5.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7605c1c32c3d6e8c990dd28a0970a3cbbf1429d5b92279e37fda05fb0c92190e", size = 5342144, upload-time = "2025-04-23T01:45:28.939Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/5d/abfcc6ab2fa0be72b2ba938abdae1f7cad4c632f8d552683ea295d55adfb/lxml-5.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ecf4c4b83f1ab3d5a7ace10bafcb6f11df6156857a3c418244cef41ca9fa3e44", size = 4825124, upload-time = "2025-04-23T01:45:31.361Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/78/6bd33186c8863b36e084f294fc0a5e5eefe77af95f0663ef33809cc1c8aa/lxml-5.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cef4feae82709eed352cd7e97ae062ef6ae9c7b5dbe3663f104cd2c0e8d94ba", size = 4876520, upload-time = "2025-04-23T01:45:34.191Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/74/4d7ad4839bd0fc64e3d12da74fc9a193febb0fae0ba6ebd5149d4c23176a/lxml-5.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:df53330a3bff250f10472ce96a9af28628ff1f4efc51ccba351a8820bca2a8ba", size = 4765016, upload-time = "2025-04-23T01:45:36.7Z" },
-    { url = "https://files.pythonhosted.org/packages/24/0d/0a98ed1f2471911dadfc541003ac6dd6879fc87b15e1143743ca20f3e973/lxml-5.4.0-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:aefe1a7cb852fa61150fcb21a8c8fcea7b58c4cb11fbe59c97a0a4b31cae3c8c", size = 5362884, upload-time = "2025-04-23T01:45:39.291Z" },
-    { url = "https://files.pythonhosted.org/packages/48/de/d4f7e4c39740a6610f0f6959052b547478107967362e8424e1163ec37ae8/lxml-5.4.0-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:ef5a7178fcc73b7d8c07229e89f8eb45b2908a9238eb90dcfc46571ccf0383b8", size = 4902690, upload-time = "2025-04-23T01:45:42.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/8c/61763abd242af84f355ca4ef1ee096d3c1b7514819564cce70fd18c22e9a/lxml-5.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d2ed1b3cb9ff1c10e6e8b00941bb2e5bb568b307bfc6b17dffbbe8be5eecba86", size = 4944418, upload-time = "2025-04-23T01:45:46.051Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c5/6d7e3b63e7e282619193961a570c0a4c8a57fe820f07ca3fe2f6bd86608a/lxml-5.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:72ac9762a9f8ce74c9eed4a4e74306f2f18613a6b71fa065495a67ac227b3056", size = 4827092, upload-time = "2025-04-23T01:45:48.943Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4a/e60a306df54680b103348545706a98a7514a42c8b4fbfdcaa608567bb065/lxml-5.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f5cb182f6396706dc6cc1896dd02b1c889d644c081b0cdec38747573db88a7d7", size = 5418231, upload-time = "2025-04-23T01:45:51.481Z" },
-    { url = "https://files.pythonhosted.org/packages/27/f2/9754aacd6016c930875854f08ac4b192a47fe19565f776a64004aa167521/lxml-5.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:3a3178b4873df8ef9457a4875703488eb1622632a9cee6d76464b60e90adbfcd", size = 5261798, upload-time = "2025-04-23T01:45:54.146Z" },
-    { url = "https://files.pythonhosted.org/packages/38/a2/0c49ec6941428b1bd4f280650d7b11a0f91ace9db7de32eb7aa23bcb39ff/lxml-5.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e094ec83694b59d263802ed03a8384594fcce477ce484b0cbcd0008a211ca751", size = 4988195, upload-time = "2025-04-23T01:45:56.685Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/75/87a3963a08eafc46a86c1131c6e28a4de103ba30b5ae903114177352a3d7/lxml-5.4.0-cp311-cp311-win32.whl", hash = "sha256:4329422de653cdb2b72afa39b0aa04252fca9071550044904b2e7036d9d97fe4", size = 3474243, upload-time = "2025-04-23T01:45:58.863Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/1f0964c4f6c2be861c50db380c554fb8befbea98c6404744ce243a3c87ef/lxml-5.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:fd3be6481ef54b8cfd0e1e953323b7aa9d9789b94842d0e5b142ef4bb7999539", size = 3815197, upload-time = "2025-04-23T01:46:01.096Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/4c/d101ace719ca6a4ec043eb516fcfcb1b396a9fccc4fcd9ef593df34ba0d5/lxml-5.4.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b5aff6f3e818e6bdbbb38e5967520f174b18f539c2b9de867b1e7fde6f8d95a4", size = 8127392, upload-time = "2025-04-23T01:46:04.09Z" },
-    { url = "https://files.pythonhosted.org/packages/11/84/beddae0cec4dd9ddf46abf156f0af451c13019a0fa25d7445b655ba5ccb7/lxml-5.4.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:942a5d73f739ad7c452bf739a62a0f83e2578afd6b8e5406308731f4ce78b16d", size = 4415103, upload-time = "2025-04-23T01:46:07.227Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/25/d0d93a4e763f0462cccd2b8a665bf1e4343dd788c76dcfefa289d46a38a9/lxml-5.4.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:460508a4b07364d6abf53acaa0a90b6d370fafde5693ef37602566613a9b0779", size = 5024224, upload-time = "2025-04-23T01:46:10.237Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ce/1df18fb8f7946e7f3388af378b1f34fcf253b94b9feedb2cec5969da8012/lxml-5.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:529024ab3a505fed78fe3cc5ddc079464e709f6c892733e3f5842007cec8ac6e", size = 4769913, upload-time = "2025-04-23T01:46:12.757Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/62/f4a6c60ae7c40d43657f552f3045df05118636be1165b906d3423790447f/lxml-5.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ca56ebc2c474e8f3d5761debfd9283b8b18c76c4fc0967b74aeafba1f5647f9", size = 5290441, upload-time = "2025-04-23T01:46:16.037Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/aa/04f00009e1e3a77838c7fc948f161b5d2d5de1136b2b81c712a263829ea4/lxml-5.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a81e1196f0a5b4167a8dafe3a66aa67c4addac1b22dc47947abd5d5c7a3f24b5", size = 4820165, upload-time = "2025-04-23T01:46:19.137Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/e0b2f61fa2404bf0f1fdf1898377e5bd1b74cc9b2cf2c6ba8509b8f27990/lxml-5.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00b8686694423ddae324cf614e1b9659c2edb754de617703c3d29ff568448df5", size = 4932580, upload-time = "2025-04-23T01:46:21.963Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a2/8263f351b4ffe0ed3e32ea7b7830f845c795349034f912f490180d88a877/lxml-5.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c5681160758d3f6ac5b4fea370495c48aac0989d6a0f01bb9a72ad8ef5ab75c4", size = 4759493, upload-time = "2025-04-23T01:46:24.316Z" },
-    { url = "https://files.pythonhosted.org/packages/05/00/41db052f279995c0e35c79d0f0fc9f8122d5b5e9630139c592a0b58c71b4/lxml-5.4.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:2dc191e60425ad70e75a68c9fd90ab284df64d9cd410ba8d2b641c0c45bc006e", size = 5324679, upload-time = "2025-04-23T01:46:27.097Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/be/ee99e6314cdef4587617d3b3b745f9356d9b7dd12a9663c5f3b5734b64ba/lxml-5.4.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:67f779374c6b9753ae0a0195a892a1c234ce8416e4448fe1e9f34746482070a7", size = 4890691, upload-time = "2025-04-23T01:46:30.009Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/36/239820114bf1d71f38f12208b9c58dec033cbcf80101cde006b9bde5cffd/lxml-5.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:79d5bfa9c1b455336f52343130b2067164040604e41f6dc4d8313867ed540079", size = 4955075, upload-time = "2025-04-23T01:46:32.33Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e1/1b795cc0b174efc9e13dbd078a9ff79a58728a033142bc6d70a1ee8fc34d/lxml-5.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3d3c30ba1c9b48c68489dc1829a6eede9873f52edca1dda900066542528d6b20", size = 4838680, upload-time = "2025-04-23T01:46:34.852Z" },
-    { url = "https://files.pythonhosted.org/packages/72/48/3c198455ca108cec5ae3662ae8acd7fd99476812fd712bb17f1b39a0b589/lxml-5.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1af80c6316ae68aded77e91cd9d80648f7dd40406cef73df841aa3c36f6907c8", size = 5391253, upload-time = "2025-04-23T01:46:37.608Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/10/5bf51858971c51ec96cfc13e800a9951f3fd501686f4c18d7d84fe2d6352/lxml-5.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4d885698f5019abe0de3d352caf9466d5de2baded00a06ef3f1216c1a58ae78f", size = 5261651, upload-time = "2025-04-23T01:46:40.183Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/11/06710dd809205377da380546f91d2ac94bad9ff735a72b64ec029f706c85/lxml-5.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aea53d51859b6c64e7c51d522c03cc2c48b9b5d6172126854cc7f01aa11f52bc", size = 5024315, upload-time = "2025-04-23T01:46:43.333Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/b0/15b6217834b5e3a59ebf7f53125e08e318030e8cc0d7310355e6edac98ef/lxml-5.4.0-cp312-cp312-win32.whl", hash = "sha256:d90b729fd2732df28130c064aac9bb8aff14ba20baa4aee7bd0795ff1187545f", size = 3486149, upload-time = "2025-04-23T01:46:45.684Z" },
-    { url = "https://files.pythonhosted.org/packages/91/1e/05ddcb57ad2f3069101611bd5f5084157d90861a2ef460bf42f45cced944/lxml-5.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1dc4ca99e89c335a7ed47d38964abcb36c5910790f9bd106f2a8fa2ee0b909d2", size = 3817095, upload-time = "2025-04-23T01:46:48.521Z" },
-    { url = "https://files.pythonhosted.org/packages/87/cb/2ba1e9dd953415f58548506fa5549a7f373ae55e80c61c9041b7fd09a38a/lxml-5.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:773e27b62920199c6197130632c18fb7ead3257fce1ffb7d286912e56ddb79e0", size = 8110086, upload-time = "2025-04-23T01:46:52.218Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/3e/6602a4dca3ae344e8609914d6ab22e52ce42e3e1638c10967568c5c1450d/lxml-5.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ce9c671845de9699904b1e9df95acfe8dfc183f2310f163cdaa91a3535af95de", size = 4404613, upload-time = "2025-04-23T01:46:55.281Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/72/bf00988477d3bb452bef9436e45aeea82bb40cdfb4684b83c967c53909c7/lxml-5.4.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9454b8d8200ec99a224df8854786262b1bd6461f4280064c807303c642c05e76", size = 5012008, upload-time = "2025-04-23T01:46:57.817Z" },
-    { url = "https://files.pythonhosted.org/packages/92/1f/93e42d93e9e7a44b2d3354c462cd784dbaaf350f7976b5d7c3f85d68d1b1/lxml-5.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cccd007d5c95279e529c146d095f1d39ac05139de26c098166c4beb9374b0f4d", size = 4760915, upload-time = "2025-04-23T01:47:00.745Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0b/363009390d0b461cf9976a499e83b68f792e4c32ecef092f3f9ef9c4ba54/lxml-5.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0fce1294a0497edb034cb416ad3e77ecc89b313cff7adbee5334e4dc0d11f422", size = 5283890, upload-time = "2025-04-23T01:47:04.702Z" },
-    { url = "https://files.pythonhosted.org/packages/19/dc/6056c332f9378ab476c88e301e6549a0454dbee8f0ae16847414f0eccb74/lxml-5.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24974f774f3a78ac12b95e3a20ef0931795ff04dbb16db81a90c37f589819551", size = 4812644, upload-time = "2025-04-23T01:47:07.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8a/f8c66bbb23ecb9048a46a5ef9b495fd23f7543df642dabeebcb2eeb66592/lxml-5.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:497cab4d8254c2a90bf988f162ace2ddbfdd806fce3bda3f581b9d24c852e03c", size = 4921817, upload-time = "2025-04-23T01:47:10.317Z" },
-    { url = "https://files.pythonhosted.org/packages/04/57/2e537083c3f381f83d05d9b176f0d838a9e8961f7ed8ddce3f0217179ce3/lxml-5.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e794f698ae4c5084414efea0f5cc9f4ac562ec02d66e1484ff822ef97c2cadff", size = 4753916, upload-time = "2025-04-23T01:47:12.823Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/80/ea8c4072109a350848f1157ce83ccd9439601274035cd045ac31f47f3417/lxml-5.4.0-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:2c62891b1ea3094bb12097822b3d44b93fc6c325f2043c4d2736a8ff09e65f60", size = 5289274, upload-time = "2025-04-23T01:47:15.916Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/47/c4be287c48cdc304483457878a3f22999098b9a95f455e3c4bda7ec7fc72/lxml-5.4.0-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:142accb3e4d1edae4b392bd165a9abdee8a3c432a2cca193df995bc3886249c8", size = 4874757, upload-time = "2025-04-23T01:47:19.793Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/04/6ef935dc74e729932e39478e44d8cfe6a83550552eaa072b7c05f6f22488/lxml-5.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1a42b3a19346e5601d1b8296ff6ef3d76038058f311902edd574461e9c036982", size = 4947028, upload-time = "2025-04-23T01:47:22.401Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f9/c33fc8daa373ef8a7daddb53175289024512b6619bc9de36d77dca3df44b/lxml-5.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4291d3c409a17febf817259cb37bc62cb7eb398bcc95c1356947e2871911ae61", size = 4834487, upload-time = "2025-04-23T01:47:25.513Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/30/fc92bb595bcb878311e01b418b57d13900f84c2b94f6eca9e5073ea756e6/lxml-5.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4f5322cf38fe0e21c2d73901abf68e6329dc02a4994e483adbcf92b568a09a54", size = 5381688, upload-time = "2025-04-23T01:47:28.454Z" },
-    { url = "https://files.pythonhosted.org/packages/43/d1/3ba7bd978ce28bba8e3da2c2e9d5ae3f8f521ad3f0ca6ea4788d086ba00d/lxml-5.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:0be91891bdb06ebe65122aa6bf3fc94489960cf7e03033c6f83a90863b23c58b", size = 5242043, upload-time = "2025-04-23T01:47:31.208Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/cd/95fa2201041a610c4d08ddaf31d43b98ecc4b1d74b1e7245b1abdab443cb/lxml-5.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:15a665ad90054a3d4f397bc40f73948d48e36e4c09f9bcffc7d90c87410e478a", size = 5021569, upload-time = "2025-04-23T01:47:33.805Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/a6/31da006fead660b9512d08d23d31e93ad3477dd47cc42e3285f143443176/lxml-5.4.0-cp313-cp313-win32.whl", hash = "sha256:d5663bc1b471c79f5c833cffbc9b87d7bf13f87e055a5c86c363ccd2348d7e82", size = 3485270, upload-time = "2025-04-23T01:47:36.133Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/14/c115516c62a7d2499781d2d3d7215218c0731b2c940753bf9f9b7b73924d/lxml-5.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:bcb7a1096b4b6b24ce1ac24d4942ad98f983cd3810f9711bcd0293f43a9d8b9f", size = 3814606, upload-time = "2025-04-23T01:47:39.028Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/b0/e4d1cbb8c078bc4ae44de9c6a79fec4e2b4151b1b4d50af71d799e76b177/lxml-5.4.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1b717b00a71b901b4667226bba282dd462c42ccf618ade12f9ba3674e1fabc55", size = 3892319, upload-time = "2025-04-23T01:49:22.069Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/aa/e2bdefba40d815059bcb60b371a36fbfcce970a935370e1b367ba1cc8f74/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27a9ded0f0b52098ff89dd4c418325b987feed2ea5cc86e8860b0f844285d740", size = 4211614, upload-time = "2025-04-23T01:49:24.599Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/5f/91ff89d1e092e7cfdd8453a939436ac116db0a665e7f4be0cd8e65c7dc5a/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b7ce10634113651d6f383aa712a194179dcd496bd8c41e191cec2099fa09de5", size = 4306273, upload-time = "2025-04-23T01:49:27.355Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7c/8c3f15df2ca534589717bfd19d1e3482167801caedfa4d90a575facf68a6/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:53370c26500d22b45182f98847243efb518d268374a9570409d2e2276232fd37", size = 4208552, upload-time = "2025-04-23T01:49:29.949Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/d8/9567afb1665f64d73fc54eb904e418d1138d7f011ed00647121b4dd60b38/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c6364038c519dffdbe07e3cf42e6a7f8b90c275d4d1617a69bb59734c1a2d571", size = 4331091, upload-time = "2025-04-23T01:49:32.842Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ab/fdbbd91d8d82bf1a723ba88ec3e3d76c022b53c391b0c13cad441cdb8f9e/lxml-5.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b12cb6527599808ada9eb2cd6e0e7d3d8f13fe7bbb01c6311255a15ded4c7ab4", size = 3487862, upload-time = "2025-04-23T01:49:36.296Z" },
 ]
 
 [[package]]
@@ -3326,17 +3251,11 @@ wheels = [
 name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "pytz", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "tzdata", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3390,77 +3309,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pandas"
-version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/35/6411db530c618e0e0005187e35aa02ce60ae4c4c4d206964a2f978217c27/pandas-3.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a727a73cbdba2f7458dc82449e2315899d5140b449015d822f515749a46cbbe0", size = 10326926, upload-time = "2026-03-31T06:46:08.29Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/d3/b7da1d5d7dbdc5ef52ed7debd2b484313b832982266905315dad5a0bf0b1/pandas-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbbd4aa20ca51e63b53bbde6a0fa4254b1aaabb74d2f542df7a7959feb1d760c", size = 9926987, upload-time = "2026-03-31T06:46:11.724Z" },
-    { url = "https://files.pythonhosted.org/packages/52/77/9b1c2d6070b5dbe239a7bc889e21bfa58720793fb902d1e070695d87c6d0/pandas-3.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:339dda302bd8369dedeae979cb750e484d549b563c3f54f3922cb8ff4978c5eb", size = 10757067, upload-time = "2026-03-31T06:46:14.903Z" },
-    { url = "https://files.pythonhosted.org/packages/20/17/ec40d981705654853726e7ac9aea9ddbb4a5d9cf54d8472222f4f3de06c2/pandas-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61c2fd96d72b983a9891b2598f286befd4ad262161a609c92dc1652544b46b76", size = 11258787, upload-time = "2026-03-31T06:46:17.683Z" },
-    { url = "https://files.pythonhosted.org/packages/90/e3/3f1126d43d3702ca8773871a81c9f15122a1f412342cc56284ffda5b1f70/pandas-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c934008c733b8bbea273ea308b73b3156f0181e5b72960790b09c18a2794fe1e", size = 11771616, upload-time = "2026-03-31T06:46:20.532Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/cf/0f4e268e1f5062e44a6bda9f925806721cd4c95c2b808a4c82ebe914f96b/pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa", size = 12337623, upload-time = "2026-03-31T06:46:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a0/97a6339859d4acb2536efb24feb6708e82f7d33b2ed7e036f2983fcced82/pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df", size = 9897372, upload-time = "2026-03-31T06:46:26.703Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/eb/781516b808a99ddf288143cec46b342b3016c3414d137da1fdc3290d8860/pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f", size = 9154922, upload-time = "2026-03-31T06:46:30.284Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
-    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
-    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
-    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
-    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
-    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
-    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
-    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
-    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
-    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
-    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
-    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
-    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
-]
-
-[[package]]
 name = "pandas-gbq"
 version = "0.35.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3473,8 +3321,7 @@ dependencies = [
     { name = "google-cloud-bigquery" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas" },
     { name = "psutil" },
     { name = "pyarrow" },
     { name = "pydata-google-auth" },
@@ -4145,12 +3992,12 @@ wheels = [
 
 [[package]]
 name = "pyspark"
-version = "4.1.1"
+version = "3.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/bf/58ee13add151469c25825b7125bbf62c3bdcec05eec4d458fcb5c5516066/pyspark-4.1.1.tar.gz", hash = "sha256:77f78984aa84fbe865c717dd37b49913b4e5c97d76ef6824f932f1aefa6621ec", size = 455359625, upload-time = "2026-01-09T09:38:38.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz", hash = "sha256:54cca0767b21b40e3953ad1d30f8601c53abf9cbda763653289cdcfcac52313c", size = 317817299, upload-time = "2026-01-15T11:46:14.487Z" }
 
 [[package]]
 name = "pytest"
@@ -4508,15 +4355,16 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.4"
+version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2188,7 +2188,7 @@ wheels = [
 
 [[package]]
 name = "kedro-databricks"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "databricks-sdk" },


### PR DESCRIPTION
This pull request introduces significant improvements to how the Databricks bundle command handles `MemoryDataset` resources in Kedro projects, adds more robust error handling, and refines configuration loading and resource generation logic. It also enhances the test suite to cover these new behaviors and improves catalog path substitution logic.

**Key changes include:**

### MemoryDataset Handling and Error Reporting

* Introduced a new `MemoryDatasetError` exception and logic to check for undeclared `MemoryDataset`s in the resource generator. If a generator (like `NodeResourceGenerator`) cannot handle `MemoryDataset`s, the bundle command now fails with a clear error message, guiding users to use the `pipeline` generator if needed. (`src/kedro_databricks/commands/bundle.py`, `src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py`, `src/kedro_databricks/utilities/resource_generator/node_resource_generator.py`, `src/kedro_databricks/utilities/resource_generator/pipeline_resource_generator.py`) [[1]](diffhunk://#diff-7f471a4b5f173fa0900af3601da7c8ebf78586cde95e60d2e02b9a78bd8ff52cL24-R44) [[2]](diffhunk://#diff-7f471a4b5f173fa0900af3601da7c8ebf78586cde95e60d2e02b9a78bd8ff52cR101-R138) [[3]](diffhunk://#diff-b6aef6331c2e00dbbfae75aa003a2c5e41e423058da3b0c6846c153c4bfbe76bR52-R88) [[4]](diffhunk://#diff-16722864080fa25671ac497fbcf36bab7eb3e99b8bd80d4b85cecbc3dac84ca1R21-R23) [[5]](diffhunk://#diff-599a5df801d58b11206de06bca77f93fa002ee520d09c6b2233ad983427bfedeR19-R21)

* Both `NodeResourceGenerator` and `PipelineResourceGenerator` now explicitly define whether they support `MemoryDataset`s via a new `can_handle_memory_datasets` method. (`src/kedro_databricks/utilities/resource_generator/node_resource_generator.py`, `src/kedro_databricks/utilities/resource_generator/pipeline_resource_generator.py`) [[1]](diffhunk://#diff-16722864080fa25671ac497fbcf36bab7eb3e99b8bd80d4b85cecbc3dac84ca1R21-R23) [[2]](diffhunk://#diff-599a5df801d58b11206de06bca77f93fa002ee520d09c6b2233ad983427bfedeR19-R21)

### Configuration and Resource Generation Refactoring

* Refactored the bundle command to use a `KedroSession` for loading configuration and context, improving reliability and consistency. The `_load_kedro_env_config` function now takes a session instead of metadata, and configuration directory creation is handled earlier. (`src/kedro_databricks/commands/bundle.py`, `src/kedro_databricks/utilities/resource_generator/abstract_resource_generator.py`) [[1]](diffhunk://#diff-7f471a4b5f173fa0900af3601da7c8ebf78586cde95e60d2e02b9a78bd8ff52cR101-R138) [[2]](diffhunk://#diff-7f471a4b5f173fa0900af3601da7c8ebf78586cde95e60d2e02b9a78bd8ff52cL192-R225) [[3]](diffhunk://#diff-7f471a4b5f173fa0900af3601da7c8ebf78586cde95e60d2e02b9a78bd8ff52cL205-L212) [[4]](diffhunk://#diff-b6aef6331c2e00dbbfae75aa003a2c5e41e423058da3b0c6846c153c4bfbe76bR52-R88)

### Testing Improvements

* Added and updated tests to verify correct error handling when `MemoryDataset`s are present and the generator does not support them, as well as successful bundling when using the pipeline generator. This includes new test cases for these scenarios and improved test setup. (`tests/unit/test_bundle.py`) [[1]](diffhunk://#diff-d370b00766ad16a4fccd0ddd6eea2fd6b92c51824ed8897dd88faab5882fee55R32) [[2]](diffhunk://#diff-d370b00766ad16a4fccd0ddd6eea2fd6b92c51824ed8897dd88faab5882fee55L80-R92) [[3]](diffhunk://#diff-d370b00766ad16a4fccd0ddd6eea2fd6b92c51824ed8897dd88faab5882fee55R104-R165) [[4]](diffhunk://#diff-d370b00766ad16a4fccd0ddd6eea2fd6b92c51824ed8897dd88faab5882fee55L113-R177) [[5]](diffhunk://#diff-d370b00766ad16a4fccd0ddd6eea2fd6b92c51824ed8897dd88faab5882fee55L122-R204)

### Catalog Path Substitution Logic

* Improved the `_substitute_file_path` function to handle more file path formats and avoid substituting URLs, with expanded test coverage for these cases. (`src/kedro_databricks/commands/init.py`, `tests/unit/test_init.py`) [[1]](diffhunk://#diff-38fc065da4598081de85a11ca63c7d745eed24971fb2880c117c14b708e20a9fL328-R341) [[2]](diffhunk://#diff-4c99501228893efd717521fd5f5029dafdcc11d76d845c19806a1df88b91a4acR72-R91)

### Miscellaneous

* Minor updates such as ensuring the default branch is set to `main` during project creation and small import cleanups. (`scripts/mkdev.py`, `src/kedro_databricks/commands/bundle.py`, `tests/unit/test_bundle.py`) [[1]](diffhunk://#diff-5b473ca52c7a6e290846b344921ee47baa8e9d8f69fe68ce1618cab17a244588R89-R90) [[2]](diffhunk://#diff-7f471a4b5f173fa0900af3601da7c8ebf78586cde95e60d2e02b9a78bd8ff52cR1) [[3]](diffhunk://#diff-d370b00766ad16a4fccd0ddd6eea2fd6b92c51824ed8897dd88faab5882fee55L16-R15)

These changes collectively improve the robustness and user experience of the Databricks bundle workflow, especially around catalog management and error messaging for in-memory datasets.